### PR TITLE
On RedHat, add VLAN=yes for interfaces matching the VLAN device name pattern

### DIFF
--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -10,3 +10,7 @@ ONBOOT={{ item.0.onboot }}
 {% if ansible_distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
+
+{% if item.1 | match('.*\.\d{1,4}') %}
+VLAN=yes
+{% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -23,3 +23,7 @@ ONBOOT={{ item.onboot }}
 {% if ansible_distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
+
+{% if item.device | match('.*\.\d{1,4}') %}
+VLAN=yes
+{% endif %}


### PR DESCRIPTION
Network interfaces for VLAN devices are named <interface>.<vlan ID>. Check for
this pattern and add VLAN=yes to the interface configuration file of tagged
VLAN interfaces.