### PR TITLE
Allow MTU to be configured on RedHat distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ define static routes and a gateway.
          network: 192.168.1.1
          dnsnameservers: 192.0.2.1 192.0.2.2
          dnssearch: example.com
+         mtu: 9000
 
          route:
           - network: 192.168.200.0
@@ -72,6 +73,7 @@ define static routes and a gateway.
           netmask: 255.255.255.0
           bootproto: static
           stp: "on"
+          mtu: 1500
           ports: [eth1, eth2]
 ```
 

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -27,3 +27,7 @@ BOOTPROTO=dhcp
 {% if ansible_distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
+
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -31,3 +31,7 @@ ONBOOT={{ item.onboot }}
 {% if ansible_distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
+
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}

--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -14,3 +14,7 @@ NM_CONTROLLED=no
 {% if item.1 | match('.*\.\d{1,4}') %}
 VLAN=yes
 {% endif %}
+
+{% if item.0.mtu is defined %}
+MTU={{ item.0.mtu }}
+{% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -27,3 +27,7 @@ NM_CONTROLLED=no
 {% if item.device | match('.*\.\d{1,4}') %}
 VLAN=yes
 {% endif %}
+
+{% if item.mtu is defined %}
+MTU={{ item.mtu }}
+{% endif %}


### PR DESCRIPTION
The MTU is applied to ethernet, bridge and bond master interfaces.