### PR TITLE
Debian needs resolvconf to handle dns-{nameservers,search}

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ interfaces_pkgs:
     - python-selinux
     - bridge-utils
     - ifenslave
+    - resolvconf
   redhat:
     - libselinux-python
     - bridge-utils


### PR DESCRIPTION
Installing resolvconf on top of isc-dhcp-client (default debian dhcp client iirc) will handle both static and dhcp NIC config without extra configuration (appart from dns-{nameservers,search} in interfaces config files).

This might need some more testing though (so far tested on Debian8/9 only).