### PR TITLE
Configure bond interfaces before bridges

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,10 +10,10 @@
   when: interfaces_ether_interfaces is defined
   tags: configuration
 
-- include: 'bridge_configuration.yml'
-  when: interfaces_bridge_interfaces is defined
-  tags: configuration
-
 - include: 'bond_configuration.yml'
   when: interfaces_bond_interfaces is defined
+  tags: configuration
+
+- include: 'bridge_configuration.yml'
+  when: interfaces_bridge_interfaces is defined
   tags: configuration


### PR DESCRIPTION
This allows us to create a bridge with a bond interface as a bridge port.