### PR TITLE
Fix rework for debian

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -67,15 +67,14 @@
 
     exit $returncode"
   vars:
-    vlan_regex: '.*\.\d{1,4}'
     ether_vlan_interfaces_changed: >
-      {{ ether_interfaces_changed | select('match', vlan_regex) | list}}
+      {{ ether_interfaces_changed | select('match', vlan_interface_regex) | list}}
     ether_non_vlan_interfaces_changed: >
-      {{ ether_interfaces_changed | reject('match', vlan_regex) | list }}
+      {{ ether_interfaces_changed | reject('match', vlan_interface_regex) | list }}
     bridge_port_vlan_interfaces_changed: >
-      {{ bridge_port_interfaces_changed | select('match', vlan_regex) | list}}
+      {{ bridge_port_interfaces_changed | select('match', vlan_interface_regex) | list}}
     bridge_port_non_vlan_interfaces_changed: >
-      {{ bridge_port_interfaces_changed | reject('match', vlan_regex) | list }}
+      {{ bridge_port_interfaces_changed | reject('match', vlan_interface_regex) | list }}
     all_interfaces_changed_map:
       Debian: >
         {{ ether_non_vlan_interfaces_changed +

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -146,8 +146,12 @@
     - item.bootproto | default == 'static'
     - "'address' in item"
     - item.address != '0.0.0.0'
-    - interface_fact.ipv4.address | default != item.address or
-      interface_fact.ipv4.netmask | default != item.netmask
+    - >
+      'ipv4' not in interface_fact or
+      'address' not in interface_fact.ipv4 or
+      interface_fact.ipv4.address != item.address or
+      'netmask' not in interface_fact.ipv4 or
+      interface_fact.ipv4.netmask != item.netmask
   vars:
     interface_fact: >
       {{ hostvars[inventory_hostname]['ansible_' ~ item.device | replace('-', '_')] }}

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,25 +8,43 @@
     state: present
 
 # We need to bounce the changed network interfaces carefully, as some
-# interfaces may depend on others. Here are the possible dependencies between
-# interface types (X -> Y means X depends on Y):
+# interfaces may depend on others. To further complicate matters, the
+# dependencies are different between RedHat and Debian systems. Here are the
+# possible dependencies between interface types (X -> Y means X depends on Y):
+#
 # Ethernet (VLAN) -> Ethernet
-# Ethernet (VLAN) -> bond
+# Ethernet (VLAN) -> bond master
 # Ethernet (VLAN) -> bridge
-# Bond slave -> bond master
+# [RedHat] Bond master -> bridge
+# [RedHat] Bond slave -> bond master
+# [Debian] Bond master -> bond slave
 # Bond slave (VLAN) -> Ethernet
-# Bond slave (VLAN) -> bridge(?)
-# Bridge port -> bridge
+# [RedHat] bridge port -> bridge
+# [Debian] bridge -> bridge port
+# [Debian] bridge -> bond master
 # Bridge port (VLAN) -> Ethernet
-# Bridge port (VLAN) -> bond
+# Bridge port (VLAN) -> bond master
 # Bridge port (VLAN) -> bridge
 #
-# This generates a number of valid orderings. We'll go with this one:
+# Note that VLAN interfaces as bond slaves do not appear to work on Debian.
+#
+# This generates a number of valid orderings. For RedHat, we'll go with this
+# one:
 # - Ethernet (non VLAN)
 # - Bridge
 # - Bond master
 # - Bridge port
 # - Bond slave
+# - Ethernet (VLAN)
+#
+# And for Debian, this one:
+#
+# - Ethernet (non VLAN)
+# - Bond slave
+# - Bond master
+# - Bridge port (non VLAN)
+# - Bridge
+# - Bridge port (VLAN)
 # - Ethernet (VLAN)
 #
 # Also, use nohup to ensure the process survives termination of the SSH
@@ -54,19 +72,28 @@
       {{ ether_interfaces_changed | select('match', vlan_regex) | list}}
     ether_non_vlan_interfaces_changed: >
       {{ ether_interfaces_changed | reject('match', vlan_regex) | list }}
-    all_interfaces_changed_default: >
-      {{ ether_non_vlan_interfaces_changed +
-         bridge_interfaces_changed +
-         bond_master_interfaces_changed +
-         bridge_port_interfaces_changed +
-         bond_slave_interfaces_changed +
-         ether_vlan_interfaces_changed }}
+    bridge_port_vlan_interfaces_changed: >
+      {{ bridge_port_interfaces_changed | select('match', vlan_regex) | list}}
+    bridge_port_non_vlan_interfaces_changed: >
+      {{ bridge_port_interfaces_changed | reject('match', vlan_regex) | list }}
     all_interfaces_changed_map:
-      Debian: "{{ all_interfaces_changed_default }}"
+      Debian: >
+        {{ ether_non_vlan_interfaces_changed +
+           bond_slave_interfaces_changed +
+           bond_master_interfaces_changed +
+           bridge_port_non_vlan_interfaces_changed +
+           bridge_interfaces_changed +
+           bridge_port_vlan_interfaces_changed +
+           ether_vlan_interfaces_changed }}
       # On RedHat, bounce any changed bond master interfaces for a second time.
       # The reason for this is unclear.
       RedHat: >
-        {{ all_interfaces_changed_default +
+        {{ ether_non_vlan_interfaces_changed +
+           bridge_interfaces_changed +
+           bond_master_interfaces_changed +
+           bridge_port_interfaces_changed +
+           bond_slave_interfaces_changed +
+           ether_vlan_interfaces_changed +
            bond_master_interfaces_changed }}
     all_interfaces_changed: "{{ all_interfaces_changed_map[ansible_os_family] }}"
   notify:

--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -5,7 +5,7 @@ ONBOOT=yes
 SLAVE=yes
 USERCTL=no
 
-{% if item.1 | match('.*\.\d{1,4}') %}
+{% if item.1 | match(vlan_interface_regex) %}
 VLAN=yes
 {% endif %}
 

--- a/templates/bridge_port_Debian.j2
+++ b/templates/bridge_port_Debian.j2
@@ -1,2 +1,5 @@
 auto {{ item.1 }}
 iface {{ item.1 }}  inet manual
+{% if item.1 | match(vlan_interface_regex) %}
+vlan-raw-device {{ item.1 | regex_replace(vlan_interface_suffix_regex, '') }}
+{% endif %}

--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -11,7 +11,7 @@ ONBOOT={{ item.0.onboot }}
 NM_CONTROLLED=no
 {% endif %}
 
-{% if item.1 | match('.*\.\d{1,4}') %}
+{% if item.1 | match(vlan_interface_regex) %}
 VLAN=yes
 {% endif %}
 

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -31,3 +31,7 @@ iface {{ item.device }} inet dhcp
 up route add -net {{ i.network }} netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }}
 {% endfor %}
 {% endif %}
+
+{% if item.device | match(vlan_interface_regex) %}
+vlan-raw-device {{ item.device | regex_replace(vlan_interface_suffix_regex, '') }}
+{% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -24,7 +24,7 @@ ONBOOT={{ item.onboot }}
 NM_CONTROLLED=no
 {% endif %}
 
-{% if item.device | match('.*\.\d{1,4}') %}
+{% if item.device | match(vlan_interface_regex) %}
 VLAN=yes
 {% endif %}
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,3 +2,7 @@
 # Regular expression matching a VLAN interface of the form
 # '<interface>.<VLAN ID>'.
 vlan_interface_regex: '.*\.\d{1,4}'
+
+# Regular expression matching the '.<VLAN ID>' suffix of a VLAN interface of
+# the form '<interface>.<VLAN ID>'.
+vlan_interface_suffix_regex: '\.\d{1,4}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,4 @@
+---
+# Regular expression matching a VLAN interface of the form
+# '<interface>.<VLAN ID>'.
+vlan_interface_regex: '.*\.\d{1,4}'


### PR DESCRIPTION
Turns out this didn't work for Debian. Some limitations still:

* VLAN interfaces a bond slaves doesn't seem to work on Ubuntu 16.04.
* To use VLANs on Ubuntu it's necessary to:
  * modprobe 8021q
  * apt install vlan