### PR TITLE
Fix use of host routes

### DIFF
--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -50,7 +50,9 @@ bond-slaves {{ item.bond_slaves|join(' ') }}
 
 {% if item.route is defined %}
 {% for i in item.route %}
-{% set route = (i.network ~ '/' ~ i.netmask) | ipaddr('net') %}
+{# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
+{% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{% set route = i.network ~ '/' ~ prefix %}
 {% if 'gateway' in i %}
 {% set route = route ~ ' via ' ~ i.gateway %}
 {% else %}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -33,7 +33,9 @@ bridge_stp {{ item.stp }}
 
 {% if item.route is defined %}
 {% for i in item.route %}
-{% set route = (i.network ~ '/' ~ i.netmask) | ipaddr('net') %}
+{# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
+{% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{% set route = i.network ~ '/' ~ prefix %}
 {% if 'gateway' in i %}
 {% set route = route ~ ' via ' ~ i.gateway %}
 {% else %}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -28,7 +28,9 @@ iface {{ item.device }} inet dhcp
 
 {% if item.route is defined %}
 {% for i in item.route %}
-{% set route = (i.network ~ '/' ~ i.netmask) | ipaddr('net') %}
+{# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
+{% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{% set route = i.network ~ '/' ~ prefix %}
 {% if 'gateway' in i %}
 {% set route = route ~ ' via ' ~ i.gateway %}
 {% else %}

--- a/templates/route_RedHat.j2
+++ b/templates/route_RedHat.j2
@@ -1,6 +1,8 @@
 # {{ansible_managed}}
 {% for i in item.route %}
-{% set route = (i.network ~ '/' ~ i.netmask) | ipaddr('net') %}
+{# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
+{% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{% set route = i.network ~ '/' ~ prefix %}
 {% if 'gateway' in i %}
 {% set route = route ~ ' via ' ~ i.gateway %}
 {% else %}


### PR DESCRIPTION
The ipaddr('net') filter does not work for host routes (/32) due to Ansible bug
17872. This change uses the ipaddr('prefix') filter instead to calculate the
subnet prefix.