### PR TITLE
Check the active interface state against configuration

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2017 StackHPC Ltd.
+
+import jinja2
+
+
+def _fail(reason):
+    return {
+        "diff": True,
+        "reason": reason,
+    }
+
+
+def _pass():
+    return {"diff": False}
+
+
+def _device(interface):
+    """Return the device associated with an interface."""
+    return interface["device"]
+
+
+def _fact_name(device):
+    """Return the name of the Ansible fact associated with an interface."""
+    return "ansible_%s" % device.replace("-", "_")
+
+
+def _fact(context, device):
+    """Return the fact associated with an interface."""
+    fact_name = _fact_name(device)
+    return context[fact_name]
+
+
+def _interface_check(context, interface, interface_type=None):
+    """Check whether the active state of an Ethernet interface is as requested.
+
+    :param context: Jinja2 context.
+    :param interface: An item in interfaces_ether_interfaces.
+    :param interface_type: The expected interface type.
+    :returns: A dict containing 'diff' and 'reason' items.
+    """
+    device = _device(interface)
+
+    # Existence
+    fact_name = _fact_name(device)
+    if fact_name not in context:
+        return _fail("Interface %s does not exist" % device)
+
+    # State
+    fact = _fact(context, device)
+    if not fact["active"]:
+        return _fail("Interface %s is not active" % device)
+
+    # Type
+    if interface_type:
+        fact_type = fact["type"]
+        if interface_type != fact_type:
+            return _fail("Interface %s is of an unexpected type" % device)
+
+    # Static IPv4 address
+    if interface.get("bootproto") == "static" and interface.get("address"):
+        fact_address = fact.get("ipv4", {}).get("address")
+        if interface["address"] != "0.0.0.0":
+            # IP address
+            if not fact_address:
+                return _fail("Interface %s has no IPv4 address" % device)
+            if fact_address != interface["address"]:
+                return _fail("Interface %s has incorrect IPv4 address" % device)
+
+            # Netmask
+            if (interface.get("netmask") and
+                    fact["ipv4"]["netmask"] != interface["netmask"]):
+                return _fail("Interface %s has incorrect IPv4 netmask" % device)
+
+            # Gateway
+            if interface.get("gateway"):
+                fact_gateway = context.get("ansible_default_ipv4", {}).get("gateway")
+                if not fact_gateway:
+                    return _fail("Default gateway is missing")
+                if interface["gateway"] != fact_gateway:
+                    return _fail("Default gateway is incorrect")
+
+        elif fact_address:
+            return _fail("Interface %s has an IPv4 address but none was "
+                         "requested" % device)
+
+    # MTU
+    if interface.get("mtu"):
+        fact_mtu = fact.get("mtu")
+        if interface["mtu"] != fact_mtu:
+            return _fail("Interface %s has incorrect MTU" % device)
+
+    return _pass()
+
+
+@jinja2.contextfilter
+def ether_check(context, interface):
+    """Check whether the active state of an Ethernet interface is as requested.
+
+    :param context: Jinja2 context.
+    :param interface: An item in interfaces_ether_interfaces.
+    :returns: A dict containing 'diff' and 'reason' items.
+    """
+    result = _interface_check(context, interface, "ether")
+    return result
+
+
+@jinja2.contextfilter
+def bridge_check(context, interface):
+    """Check whether the active state of a bridge interface is as requested.
+
+    :param context: Jinja2 context.
+    :param interface: An item in interfaces_ether_interfaces.
+    :returns: A dict containing 'diff' and 'reason' items.
+    """
+    result = _interface_check(context, interface, "bridge")
+    if result["diff"]:
+        return result
+
+    device = _device(interface)
+    fact = _fact(context, device)
+
+    # Bridge ports
+    fact_ports = fact.get("interfaces", [])
+    interface_ports = interface.get("ports", [])
+    missing = set(interface_ports) - set(fact_ports)
+    if missing:
+        return _fail("Bridge interface %s has missing ports: %s" %
+                     (device, ", ".join(missing)))
+
+    for port in interface_ports:
+        port_interface = {"device": port}
+        result = _interface_check(context, port_interface)
+        if result["diff"]:
+            return result
+
+    return result
+
+
+@jinja2.contextfilter
+def bond_check(context, interface):
+    """Check whether the active state of a bond interface is as requested.
+
+    :param context: Jinja2 context.
+    :param interface: An item in interfaces_ether_interfaces.
+    :returns: A dict containing 'diff' and 'reason' items.
+    """
+    result = _interface_check(context, interface, "bonding")
+    if result["diff"]:
+        return result
+
+    device = _device(interface)
+    fact = _fact(context, device)
+
+    # Bond mode
+    if interface.get("bond_mode"):
+        fact_mode = fact["mode"]
+        # Convert numerical modes to the named modes presented by ansible.
+        mode_lookup = {
+            "1": "active-backup",
+            "2": "balance-xor",
+            "3": "broadcast",
+            "4": "802.3ad",
+            "5": "balance-tlb",
+            "6": "balance-alb",
+        }
+        interface_mode = str(interface["bond_mode"])
+        interface_mode = mode_lookup.get(interface_mode, interface_mode)
+        if interface_mode != fact["mode"]:
+            return _fail("Bond interface %s has incorrect bond mode" % device)
+
+    # Bond miimon
+    if interface.get("bond_miimon"):
+        fact_miimon = fact["miimon"]
+        if str(interface["bond_miimon"]) != fact["miimon"]:
+            return _fail("Bond interface %s has incorrect miimon" % device)
+
+    # Bond slaves
+    fact_slaves = fact.get("slaves", [])
+    interface_slaves = interface.get("bond_slaves", [])
+    missing = set(interface_slaves) - set(fact_slaves)
+    if missing:
+        return _fail("Bond interface %s has missing slaves: %s" %
+                     (device, ", ".join(missing)))
+    additional = set(fact_slaves) - set(interface_slaves)
+    if additional:
+        return _fail("Bond interface %s has additional slaves: %s" %
+                     (device, ", ".join(additional)))
+
+    for slave in interface_slaves:
+        slave_interface = {"device": slave}
+        result = _interface_check(context, slave_interface, "ether")
+        if result["diff"]:
+            return result
+
+    return result
+
+
+class FilterModule(object):
+    """Interface comparison filters."""
+
+    def filters(self):
+        return {
+            'ether_check': ether_check,
+            'bridge_check': bridge_check,
+            'bond_check': bond_check,
+        }

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -137,92 +137,35 @@
     all_interfaces_changed: "{{ all_interfaces_changed_map[ansible_os_family] }}"
   notify:
     - Gather facts
-    - Verify network interfaces exist
-    - Verify network interfaces are active
-    - Verify network interface IP configuration
-    - Verify bond interface slaves
-    - Verify bridge interface ports
+    - Check active Ethernet interface state
+    - Check active bond interface state
+    - Check active bridge interface state
 
 # Update host facts so that we can verify the configuration has been applied
 # correctly.
 - name: Gather facts
   setup:
 
-- name: Verify network interfaces exist
+- name: Check active Ethernet interface state
   fail:
-    msg: >
-      Network interface {{ item }} does not exist.
-  with_flattened:
-    - "{{ ether_interfaces_changed }}"
-    - "{{ bridge_interfaces_changed }}"
-    - "{{ bond_master_interfaces_changed }}"
-    - "{{ bridge_port_interfaces_changed }}"
-    - "{{ bond_slave_interfaces_changed }}"
-  when: "'ansible_' ~ (item | replace('-', '_')) not in hostvars[inventory_hostname]"
-
-- name: Verify network interfaces are active
-  fail:
-    msg: >
-      Network interface {{ item }} is not active.
-  with_flattened:
-    - "{{ ether_interfaces_changed }}"
-    - "{{ bridge_interfaces_changed }}"
-    - "{{ bond_master_interfaces_changed }}"
-    - "{{ bridge_port_interfaces_changed }}"
-    - "{{ bond_slave_interfaces_changed }}"
-  when: not hostvars[inventory_hostname]['ansible_' ~ item | replace('-', '_')].active
-
-- name: Verify network interface IP configuration
-  fail:
-    msg: >
-      Unexpected IP configuration for interface {{ item.device }}.
-  with_flattened:
-    - "{{ interfaces_ether_interfaces }}"
-    - "{{ interfaces_bond_interfaces }}"
-    - "{{ interfaces_bridge_interfaces }}"
-  when:
-    - item.device in interfaces_changed
-    - item.bootproto | default == 'static'
-    - "'address' in item"
-    - item.address != '0.0.0.0'
-    - >
-      'ipv4' not in interface_fact or
-      'address' not in interface_fact.ipv4 or
-      interface_fact.ipv4.address != item.address or
-      'netmask' not in interface_fact.ipv4 or
-      interface_fact.ipv4.netmask != item.netmask
+    msg: "{{ ether_check.reason }}"
+  with_items: "{{ interfaces_ether_interfaces }}"
+  when: ether_check.diff
   vars:
-    interface_fact: >
-      {{ hostvars[inventory_hostname]['ansible_' ~ item.device | replace('-', '_')] }}
-    interfaces_changed: >
-      {{ ether_interfaces_changed +
-         bond_master_interfaces_changed +
-         bridge_interfaces_changed }}
+    ether_check: "{{ item | ether_check }}"
 
-- name: Verify bond interface slaves
+- name: Check active bond interface state
   fail:
-    msg: >
-      Interface {{ item.1 }} is not a slave of bond {{ item.0.device }}.
-  with_subelements:
-    - "{{ interfaces_bond_interfaces }}"
-    - "bond_slaves"
-  when:
-    - item.1 in bond_slave_interfaces_changed
-    - item.1 not in interface_fact.slaves | default([])
+    msg: "{{ bond_check.reason }}"
+  with_items: "{{ interfaces_bond_interfaces }}"
+  when: bond_check.diff
   vars:
-    interface_fact: >
-      {{ hostvars[inventory_hostname]['ansible_' ~ item.0.device | replace('-', '_')] }}
+    bond_check: "{{ item | bond_check }}"
 
-- name: Verify bridge interface ports
+- name: Check active bridge interface state
   fail:
-    msg: >
-      Interface {{ item.1 }} is not a port on bridge {{ item.0.device }}.
-  with_subelements:
-    - "{{ interfaces_bridge_interfaces }}"
-    - "ports"
-  when:
-    - item.0.device in bridge_interfaces_changed
-    - item.1 not in interface_fact.interfaces | default([])
+    msg: "{{ bridge_check.reason }}"
+  with_items: "{{ interfaces_bridge_interfaces }}"
+  when: bridge_check.diff
   vars:
-    interface_fact: >
-      {{ hostvars[inventory_hostname]['ansible_' ~ item.0.device | replace('-', '_')] }}
+    bridge_check: "{{ item | bridge_check }}"

--- a/tasks/bond_configuration.yml
+++ b/tasks/bond_configuration.yml
@@ -1,4 +1,18 @@
 ---
+
+- name: Check active bond interface state
+  debug:
+    msg: >
+      Checking bond interface configuration for {{ item.device }}:
+      {{ bond_check }}
+  with_items: "{{ interfaces_bond_interfaces }}"
+  changed_when: bond_check.diff
+  register: bond_check_result
+  notify:
+    - Bounce network devices
+  vars:
+    bond_check: "{{ item | bond_check }}"
+
 - name: Create the network configuration file for bond devices
   template:
     src: 'bond_{{ ansible_os_family }}.j2'
@@ -67,7 +81,8 @@
   set_fact:
     # Build a list of all bond master results.
     all_bond_master_results: >
-      {{ bond_result.results | default([]) +
+      {{ bond_check_result.results | default([]) +
+         bond_result.results | default([]) +
          bond_route_add_result.results | default([]) +
          bond_route_del_result.results | default([]) +
          bond_rule_add_result.results | default([]) +

--- a/tasks/bridge_configuration.yml
+++ b/tasks/bridge_configuration.yml
@@ -1,5 +1,18 @@
 ---
 
+- name: Check active bridge interface state
+  debug:
+    msg: >
+      Checking bridge interface configuration for {{ item.device }}:
+      {{ bridge_check }}
+  with_items: "{{ interfaces_bridge_interfaces }}"
+  changed_when: bridge_check.diff
+  register: bridge_check_result
+  notify:
+    - Bounce network devices
+  vars:
+    bridge_check: "{{ item | bridge_check }}"
+
 - name: Create the network configuration file for bridge devices
   template:
     src: 'bridge_{{ ansible_os_family }}.j2'
@@ -67,7 +80,8 @@
   set_fact:
     # Build a list of all bridge results.
     all_bridge_results: >
-      {{ bridge_result.results | default([]) +
+      {{ bridge_check_result.results | default([]) +
+         bridge_result.results | default([]) +
          bridge_route_add_result.results | default([]) +
          bridge_route_del_result.results | default([]) +
          bridge_rule_add_result.results | default([]) +

--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -1,5 +1,18 @@
 ---
 
+- name: Check active Ethernet interface state
+  debug:
+    msg: >
+      Checking Ethernet interface configuration for {{ item.device }}:
+      {{ ether_check }}
+  with_items: "{{ interfaces_ether_interfaces }}"
+  changed_when: ether_check.diff
+  register: ether_check_result
+  notify:
+    - Bounce network devices
+  vars:
+    ether_check: "{{ item | ether_check }}"
+
 - name: Create the network configuration file for ethernet devices
   template:
     src: 'ethernet_{{ ansible_os_family }}.j2'
@@ -53,7 +66,8 @@
   set_fact:
     # Build a list of all Ethernet results.
     all_ether_results: >
-      {{ ether_result.results | default([]) +
+      {{ ether_check_result.results | default([]) +
+         ether_result.results | default([]) +
          ether_route_add_result.results | default([]) +
          ether_route_del_result.results | default([]) +
          ether_rule_add_result.results | default([]) +


### PR DESCRIPTION
Sometimes the configuration files written to a host may not change, but the
active network state does not match the requested configuration. This can
happen following a previous configuration failure, where the configuration
files were successfully written but bouncing one or more interfaces failed. We
can also use this check after bouncing the interfaces to check that the
configuration has been successfully applied.

Currently IP routing tables, rules and routes are not checked, as these are not
available as ansible facts. In future, a routing fact gathering module could be
built to gather the required facts.