### PR TITLE
Support for hot-pluggable wifi interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,29 @@ configures an IP route on the interface for the `myroutetable` routing table.
           - from 192.168.200.0/24 table myroutetable
 ```
 
-6) All the above examples show how to configure a single host, The below
+6) Configure a hot-pluggable Wifi interface `wlan0` with a static IP and a
+`wpa_supplicant` configuration. Also configure eth0 with a dhcp IP. 
+
+```yaml
+- hosts: myhost
+  roles:
+    - role: MichaelRigart.interfaces
+      interfaces_ether_interfaces:
+        - device: wlan0
+          allowclass: allow-hotplug
+          bootproto: static
+          address: 192.168.1.150
+          netmask: 255.255.255.0
+          network: 192.168.1.0
+          broadcast: 192.168.1.255
+          gateway: 192.168.1.1
+          dnsnameservers: 192.168.1.1
+          wpaconf: /etc/wpa_supplicant/wpa_supplicant.conf
+        - device: eth0
+          bootproto: dhcp
+```
+
+7) All the above examples show how to configure a single host, The below
 example shows how to define your network configurations for all your machines.
 
 Assume your host inventory is as follows:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -95,11 +95,11 @@
     nohup bash -c "
     returncode=0
     {% for interface in all_interfaces_changed | reverse %}
-    ifdown {{ interface }};
+    ifdown --allow auto {{ interface }};
     {% endfor %}
 
     {% for interface in all_interfaces_changed %}
-    if ! ifup {{ interface }}; then
+    if ! ifup --allow auto {{ interface }}; then
       echo \"Failed to bring up interface {{ interface }}\";
       returncode=1
     fi;

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -89,17 +89,27 @@
 #
 # Also, use nohup to ensure the process survives termination of the SSH
 # connection.
+#
+# Note on "--allow" flag for Debian systems:
+#
+# On Debian system the "--allow" flag to "ifup/ifdown" behaves like a filter
+# to the interfaces configured in /etc/network/interfaces. On Debian you
+# cannot bounce an interface marked with "allow-hotplug" (e.g. a hot-pluggable
+# wifi interface) using "ifup/ifdown", it will fail. Adding the "--allow auto"
+# argument to "ifup/ifdown" will only be effective for interfaces marked with
+# "auto". Interfaces marked with "allow-hotplug" will simply be ignored then.
+#
 
 - name: Bounce network devices
   command: >
     nohup bash -c "
     returncode=0
     {% for interface in all_interfaces_changed | reverse %}
-    ifdown --allow auto {{ interface }};
+    ifdown {% if ansible_os_family == 'Debian' %}--allow auto {% endif %}{{ interface }};
     {% endfor %}
 
     {% for interface in all_interfaces_changed %}
-    if ! ifup --allow auto {{ interface }}; then
+    if ! ifup {% if ansible_os_family == 'Debian' %}--allow auto {% endif %}{{ interface }}; then
       echo \"Failed to bring up interface {{ interface }}\";
       returncode=1
     fi;

--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -14,7 +14,7 @@
   with_items: '{{ interfaces_ether_interfaces }}'
   when: item.route is defined and ansible_os_family == 'RedHat'
 
-- name: Restart Networking
-  service:
-    name: networking
-    state: restarted
+- name: Bounce ethernet devices
+  shell: 'ifdown {{ item.item.device }}; ifup {{ item.item.device }}'
+  with_items: '{{ ether_result.results }}'
+  when: ether_result is defined and item.changed

--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -14,7 +14,7 @@
   with_items: '{{ interfaces_ether_interfaces }}'
   when: item.route is defined and ansible_os_family == 'RedHat'
 
-- name: Bounce ethernet devices
-  shell: 'ifdown {{ item.item.device }}; ifup {{ item.item.device }}'
-  with_items: '{{ ether_result.results }}'
-  when: ether_result is defined and item.changed
+- name: Restart Networking
+  service:
+    name: networking
+    state: restarted

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -1,5 +1,5 @@
 {% if item.bootproto == 'static' %}
-auto {{ item.device }}
+{{ item.allowclass | default('auto') }} {{ item.device }}
 iface {{ item.device }} inet static
 {% if item.wpaconf is defined %}
 wpa-conf {{ item.wpaconf }}
@@ -26,7 +26,7 @@ dns-search {{ item.dnssearch }}
 
 
 {% if item.bootproto == 'dhcp' %}
-auto {{ item.device }}
+{{ item.allowclass | default('auto') }} {{ item.device }}
 iface {{ item.device }} inet dhcp
 {% if item.wpaconf is defined %}
 wpa-conf {{ item.wpaconf }}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -1,9 +1,9 @@
 {% if item.bootproto == 'static' %}
 auto {{ item.device }}
 iface {{ item.device }} inet static
-    {% if item.wpaconf is defined %}
-    wpa-conf {{ item.wpaconf }}
-    {% endif %}
+{% if item.wpaconf is defined %}
+wpa-conf {{ item.wpaconf }}
+{% endif %}
 {% if item.mtu is defined %}
 mtu {{ item.mtu }}
 {% endif %}
@@ -28,9 +28,9 @@ dns-search {{ item.dnssearch }}
 {% if item.bootproto == 'dhcp' %}
 auto {{ item.device }}
 iface {{ item.device }} inet dhcp
-    {% if item.wpaconf is defined %}
-    wpa-conf {{ item.wpaconf }}
-    {% endif %}
+{% if item.wpaconf is defined %}
+wpa-conf {{ item.wpaconf }}
+{% endif %}
 {% endif %}
 
 {% if item.route is defined %}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -1,6 +1,9 @@
 {% if item.bootproto == 'static' %}
 auto {{ item.device }}
 iface {{ item.device }} inet static
+    {% if item.wpaconf is defined %}
+    wpa-conf {{ item.wpaconf }}
+    {% endif %}
 {% if item.mtu is defined %}
 mtu {{ item.mtu }}
 {% endif %}
@@ -21,9 +24,13 @@ dns-nameservers {{ item.dnsnameservers }}
 dns-search {{ item.dnssearch }}
 {% endif %}
 
+
 {% if item.bootproto == 'dhcp' %}
 auto {{ item.device }}
 iface {{ item.device }} inet dhcp
+    {% if item.wpaconf is defined %}
+    wpa-conf {{ item.wpaconf }}
+    {% endif %}
 {% endif %}
 
 {% if item.route is defined %}


### PR DESCRIPTION
* 2 optional configs for interfaces_ether_interfaces
  * allowclass: anything other than 'auto'
  * wpa-conf: wpa_supplicant configuration
* add "--allow auto" flag to ifup/ifdown to only bounce 'auto' interfaces