### PR TITLE
State 'installed' is deprecated. Using state 'present' defaults value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ interfaces_pkgs:
 interfaces_net_path:
   debian: /etc/network/interfaces.d
   redhat: /etc/sysconfig/network-scripts
-interfaces_pkg_state: installed
+interfaces_pkg_state: present
 interfaces_route_tables: []
 interfaces_ether_interfaces: []
 interfaces_bridge_interfaces: []


### PR DESCRIPTION
State 'installed' is deprecated. Using state 'present' 
instead.. This feature will be removed in version 2.9