### PR TITLE
deprecation Using tests as filters is deprecated

### DIFF
--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -29,7 +29,7 @@ ONBOOT={{ item.onboot }}
 NM_CONTROLLED=no
 {% endif %}
 
-{% if item.device | match(vlan_interface_regex) %}
+{% if item.device is match(vlan_interface_regex) %}
 VLAN=yes
 {% endif %}
 


### PR DESCRIPTION
Using tests as filters is deprecated. Instead of using 
`result|match` use `result is match`. This feature will be removed in version 
2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False
 in ansible.cfg.