### PR TITLE
Using tests as filters is deprecated

### DIFF
--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -58,7 +58,7 @@ down ip rule del {{ rule }}
 {% endfor %}
 {% endif %}
 
-{% if item.device | match(vlan_interface_regex) %}
+{% if item.device is match(vlan_interface_regex) %}
 vlan-raw-device {{ item.device | regex_replace(vlan_interface_suffix_regex, '') }}
 {% endif %}
 


### PR DESCRIPTION
TASK [michaelrigart.interfaces : Create the network configuration file for ethernet devices] ***
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using 
`result|match` use `result is match`. This feature will be removed in version 
2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False
 in ansible.cfg.