### PR TITLE
Fix bridge configuration when using DHCP

### DIFF
--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -17,7 +17,7 @@ GATEWAY={{ item.gateway }}
 {% endif %}
 
 {% if item.bootproto == 'dhcp' %}
-TYPE=bridge
+TYPE=Bridge
 BOOTPROTO=dhcp
 {% if item.stp is defined %}
 STP={{ item.stp }}


### PR DESCRIPTION
The value of the TYPE directive is case sensitive. Using `bridge` instead of `Bridge` fails to configure the network correctly.

Closes #53.