### PR TITLE
Add support for Red Hat DEFROUTE directive

### DIFF
--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -17,6 +17,10 @@ GATEWAY={{ item.gateway }}
 BOOTPROTO=dhcp
 {% endif %}
 
+{% if item.defroute is defined %}
+DEFROUTE={{ item.defroute | ternary('yes', 'no') }}
+{% endif %}
+
 ONBOOT={{ item.onboot|default("yes") }}
 BONDING_OPTS="{% if item.bond_mode is defined %}mode={{ item.bond_mode }} {% endif %}miimon={{ item.bond_miimon|default(100) }} {% if item.bond_updelay is defined %}updelay={{ item.bond_updelay }} {% endif %} {% if item.bond_downdelay is defined %}downdelay={{ item.bond_downdelay }} {% endif %} {% if item.bond_xmit_hash_policy is defined %}xmit_hash_policy={{ item.bond_xmit_hash_policy }} {% endif %} {% if item.bond_lacp_rate is defined %}lacp_rate={{ item.bond_lacp_rate }} {% endif %} "
 

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -24,6 +24,10 @@ STP={{ item.stp }}
 {% endif %}
 {% endif %}
 
+{% if item.defroute is defined %}
+DEFROUTE={{ item.defroute | ternary('yes', 'no') }}
+{% endif %}
+
 {% if item.onboot is defined %}
 ONBOOT={{ item.onboot }}
 {% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -21,6 +21,10 @@ DNS{{ loop.index + 1 }}={{ dns_server }}
 BOOTPROTO=dhcp
 {% endif %}
 
+{% if item.defroute is defined %}
+DEFROUTE={{ item.defroute | ternary('yes', 'no') }}
+{% endif %}
+
 {% if item.onboot is defined %}
 ONBOOT={{ item.onboot }}
 {% endif %}


### PR DESCRIPTION
When configuring multiple interfaces using DHCP, this allows to specify which ones shouldn't provide a default gateway by setting `defroute` to a false value.