### PR TITLE
Add ``become: true`` to some tasks

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,16 +5,19 @@
 # Some systems do not support /etc/modules-load.d, in which case we fall back
 # to /etc/modules.
 - name: Check whether /etc/modules-load.d exists
+  become: true
   stat:
     path: /etc/modules-load.d
   register: modules_load_stat
 
 - name: Make sure the bonding module is loaded
+  become: true
   modprobe:
     name: bonding
     state: present
 
 - name: Make sure the bonding module is loaded at boot via /etc/modules-load.d
+  become: true
   template:
     src: module.conf.j2
     dest: /etc/modules-load.d/bonding.conf
@@ -23,17 +26,20 @@
     module_name: bonding
 
 - name: Make sure the bonding module is loaded at boot via /etc/modules
+  become: true
   lineinfile:
     dest: /etc/modules
     line: bonding
   when: not modules_load_stat.stat.exists
 
 - name: Make sure the 8021q module is loaded
+  become: true
   modprobe:
     name: 8021q
     state: present
 
 - name: Make sure the 8021q module is loaded at boot via /etc/modules-load.d
+  become: true
   template:
     src: module.conf.j2
     dest: /etc/modules-load.d/8021q.conf
@@ -42,6 +48,7 @@
     module_name: 8021q
 
 - name: Make sure the 8021q module is loaded at boot via /etc/modules
+  become: true
   lineinfile:
     dest: /etc/modules
     line: 8021q
@@ -101,6 +108,7 @@
 #
 
 - name: Bounce network devices
+  become: true
   command: >
     nohup bash -c "
     returncode=0

--- a/tasks/bond_configuration.yml
+++ b/tasks/bond_configuration.yml
@@ -14,6 +14,7 @@
     bond_check: "{{ item | bond_check }}"
 
 - name: Create the network configuration file for bond devices
+  become: true
   template:
     src: 'bond_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/ifcfg-{{ item.device }}'
@@ -27,6 +28,7 @@
     - Bounce network devices
 
 - name: RedHat | Write configuration files for rhel route configuration
+  become: true
   template:
     src: 'route_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
@@ -37,6 +39,7 @@
     - Bounce network devices
 
 - name: RedHat | Remove configuration files for rhel route configuration
+  become: true
   file:
     path: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
     state: absent
@@ -47,6 +50,7 @@
     - Bounce network devices
 
 - name: RedHat | Write configuration files for rhel rule configuration
+  become: true
   template:
     src: 'rule_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
@@ -57,6 +61,7 @@
     - Bounce network devices
 
 - name: RedHat | Remove configuration files for rhel rule configuration
+  become: true
   file:
     path: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
     state: absent
@@ -67,6 +72,7 @@
     - Bounce network devices
 
 - name: Create the network configuration file for slave in the bond devices
+  become: true
   template:
     src: 'bond_slave_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/ifcfg-{{ item.1 }}'

--- a/tasks/bridge_configuration.yml
+++ b/tasks/bridge_configuration.yml
@@ -1,6 +1,6 @@
 ---
-
 - name: Check active bridge interface state
+  become: true
   debug:
     msg: >
       Checking bridge interface configuration for {{ item.device }}:
@@ -14,6 +14,7 @@
     bridge_check: "{{ item | bridge_check }}"
 
 - name: Create the network configuration file for bridge devices
+  become: true
   template:
     src: 'bridge_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/ifcfg-{{ item.device }}'
@@ -23,6 +24,7 @@
     - Bounce network devices
 
 - name: RedHat | Write configuration files for rhel route configuration
+  become: true
   template:
     src: 'route_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
@@ -33,6 +35,7 @@
     - Bounce network devices
 
 - name: RedHat | Remove configuration files for rhel route configuration
+  become: true
   file:
     path: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
     state: absent
@@ -43,6 +46,7 @@
     - Bounce network devices
 
 - name: RedHat | Write configuration files for rhel rule configuration
+  become: true
   template:
     src: 'rule_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
@@ -53,6 +57,7 @@
     - Bounce network devices
 
 - name: RedHat | Remove configuration files for rhel rule configuration
+  become: true
   file:
     path: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
     state: absent
@@ -63,6 +68,7 @@
     - Bounce network devices
 
 - name: Create the network configuration file for port on the bridge devices
+  become: true
   template:
     src: 'bridge_port_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/ifcfg-{{ item.1 }}'

--- a/tasks/bridge_configuration.yml
+++ b/tasks/bridge_configuration.yml
@@ -1,6 +1,5 @@
 ---
 - name: Check active bridge interface state
-  become: true
   debug:
     msg: >
       Checking bridge interface configuration for {{ item.device }}:

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Debian | install current/latest network packages versions
   apt:
     pkg: '{{ interfaces_pkgs["debian"]  }}'
@@ -7,8 +6,10 @@
     update_cache: yes
     cache_valid_time: 3600
   tags: package
+  become: true
 
 - name: Debian | install VLAN packages
+  become: true
   apt:
     pkg: vlan
     state: '{{ interfaces_pkg_state }}'
@@ -32,6 +33,7 @@
   tags: package
 
 - name: Debian | Copy new interfaces file to source interfaces.d
+  become: true
   template:
     src: interfaces.j2
     dest: /etc/network/interfaces
@@ -41,6 +43,7 @@
   tags: configuration
 
 - name: Debian | Create the directory for interface cfg files
+  become: true
   file:
     path: '{{ interfaces_net_path[ansible_os_family|lower] }}'
     state: directory

--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -1,6 +1,6 @@
 ---
-
 - name: Check active Ethernet interface state
+  become: true
   debug:
     msg: >
       Checking Ethernet interface configuration for {{ item.device }}:
@@ -14,6 +14,7 @@
     ether_check: "{{ item | ether_check }}"
 
 - name: Create the network configuration file for ethernet devices
+  become: true
   template:
     src: 'ethernet_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/ifcfg-{{ item.device }}'
@@ -23,6 +24,7 @@
     - Bounce network devices
 
 - name: RedHat | Write configuration files for rhel route configuration
+  become: true
   template:
     src: 'route_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
@@ -33,6 +35,7 @@
     - Bounce network devices
 
 - name: RedHat | Write configuration files for rhel v6 route configuration
+  become: true
   template:
     src: 'route6_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/route6-{{ item.device }}'
@@ -43,6 +46,7 @@
     - Bounce network devices
 
 - name: RedHat | Remove configuration files for rhel route configuration
+  become: true
   file:
     path: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
     state: absent
@@ -53,6 +57,7 @@
     - Bounce network devices
 
 - name: RedHat | Remove configuration files for rhel v6 route configuration
+  become: true
   file:
     path: '{{ interfaces_net_path[ansible_os_family|lower] }}/route6-{{ item.device }}'
     state: absent
@@ -63,6 +68,7 @@
     - Bounce network devices
 
 - name: RedHat | Write configuration files for rhel rule configuration
+  become: true
   template:
     src: 'rule_{{ ansible_os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
@@ -73,6 +79,7 @@
     - Bounce network devices
 
 - name: RedHat | Remove configuration files for rhel rule configuration
+  become: true
   file:
     path: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
     state: absent

--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -1,6 +1,5 @@
 ---
 - name: Check active Ethernet interface state
-  become: true
   debug:
     msg: >
       Checking Ethernet interface configuration for {{ item.device }}:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,7 +1,7 @@
 ---
-
 - name: RedHat | install current/latest network packages versions
-  yum:
+  become: true
+  package:
     name: '{{  interfaces_pkgs["redhat"]  }}'
     state: '{{ interfaces_pkg_state }}'
   tags: package

--- a/tasks/route_table_configuration.yml
+++ b/tasks/route_table_configuration.yml
@@ -1,6 +1,6 @@
 ---
-
 - name: Ensure IP routing tables are defined
+  become: true
   blockinfile:
     dest: /etc/iproute2/rt_tables
     block: |


### PR DESCRIPTION
I don't like to execute ansible roles with a general ``become: yes``.
So I added ``become: true`` to some of your tasks until your role worked for me well.

Maybe you want to take it?

As far as I know it does not hurt to add the ``become: true`` option on some points. especially when your playbook needs root permissions and is usually executet as root!