### PR TITLE
Set bridge_ports to none for a bridge without ports

### DIFF
--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -14,7 +14,7 @@ netmask {{ item.netmask }}
 gateway {{ item.gateway }}
 {% endif %}
 {% if item.ports is defined %}
-bridge_ports {{ item.ports|join(' ') }}
+bridge_ports {{ item.ports|join(' ') }}{% if item.ports | default([], true) | length == 0 %}none{% endif %}
 {% endif %}
 {% if item.stp is defined %}
 bridge_stp {{ item.stp }}


### PR DESCRIPTION
On Debian/Ubuntu systems, if we want a bridge without any ports, we
need the following line in the interface file:

bridge_ports none

This change adds the above when a bridge has a 'ports' attribute that is
None or set to an empty list.