### PR TITLE
Fix use of 'match' test as filter

### DIFF
--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -5,7 +5,7 @@ ONBOOT=yes
 SLAVE=yes
 USERCTL=no
 
-{% if item.1 | match(vlan_interface_regex) %}
+{% if item.1 is match(vlan_interface_regex) %}
 VLAN=yes
 {% endif %}
 

--- a/templates/bridge_port_Debian.j2
+++ b/templates/bridge_port_Debian.j2
@@ -1,5 +1,5 @@
 auto {{ item.1 }}
 iface {{ item.1 }}  inet manual
-{% if item.1 | match(vlan_interface_regex) %}
+{% if item.1 is match(vlan_interface_regex) %}
 vlan-raw-device {{ item.1 | regex_replace(vlan_interface_suffix_regex, '') }}
 {% endif %}

--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -11,7 +11,7 @@ ONBOOT={{ item.0.onboot }}
 NM_CONTROLLED=no
 {% endif %}
 
-{% if item.1 | match(vlan_interface_regex) %}
+{% if item.1 is match(vlan_interface_regex) %}
 VLAN=yes
 {% endif %}
 


### PR DESCRIPTION
We currently see the following warning on Ansible 2.8:

DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of
using result|match use result is match. This feature will be removed in
version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.

2.9 is here, and now fails on this.

This change switches from '|' to 'is' for the 'match' test.

Fixes: #44