### PR TITLE
Add support for CentOS 8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,10 +8,15 @@ interfaces_pkgs:
     - iproute2
     - resolvconf
   redhat:
-    - libselinux-python
-    - bridge-utils
-    - iproute
-    - iputils
+    '7':
+      - libselinux-python
+      - bridge-utils
+      - iproute
+      - iputils
+    '8':
+      - iproute
+      - iputils
+      - network-scripts
 interfaces_net_path:
   debian: /etc/network/interfaces.d
   redhat: /etc/sysconfig/network-scripts

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -2,6 +2,6 @@
 - name: RedHat | install current/latest network packages versions
   become: true
   package:
-    name: '{{  interfaces_pkgs["redhat"]  }}'
+    name: '{{  interfaces_pkgs["redhat"][ansible_distribution_major_version] }}'
     state: '{{ interfaces_pkg_state }}'
   tags: package


### PR DESCRIPTION
On CentOS/RHEL 8 it is necessary to install the network-scripts package in order to
use network-scripts. Also, bridge-utils is no longer available.