### PR TITLE
Fix persistent network configuration on RHEL/CentOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,26 @@ may need to have a control interface that you do *not* modify using this
 method so that Ansible has a stable connection to configure the target
 systems.
 
+9) CentOS 8 cloud image workaround
+
+CentOS 8 cloud images ship with an ifcfg file for ens3. This seems to be a
+relic from the image build process, and causes the network service to fail.
+This role will by default remove this file, if there is no ens3 interface on
+the system, and no ens3 interface is specified in the role variables.
+
+This workaround is configured via `interfaces_workaround_centos_remove`. To
+set a different interface file to remove:
+
+```yaml
+interfaces_workaround_centos_remove:
+  - eth1
+```
+
+Or to avoid performing this workaround:
+
+```yaml
+interfaces_workaround_centos_remove: []
+```
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,5 @@ interfaces_route_tables: []
 interfaces_ether_interfaces: []
 interfaces_bridge_interfaces: []
 interfaces_bond_interfaces: []
+interfaces_workaround_centos_remove:
+  - ens3

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -5,3 +5,10 @@
     name: '{{  interfaces_pkgs["redhat"][ansible_distribution_major_version] }}'
     state: '{{ interfaces_pkg_state }}'
   tags: package
+
+- name: RedHat | ensure network service is started and enabled
+  become: true
+  service:
+    name: network
+    enabled: true
+    state: started

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -6,6 +6,24 @@
     state: '{{ interfaces_pkg_state }}'
   tags: package
 
+# CentOS 8 cloud images ship with an ifcfg file for ens3. This seems to be a
+# relic from the image build process, and causes the network service to fail.
+# Remove this file.
+
+- name: RedHat | remove invalid interface configuration
+  become: true
+  file:
+    path: "/etc/sysconfig/network-scripts/ifcfg-{{ item }}"
+    state: absent
+  when:
+    - item not in ansible_interfaces
+    - item not in interfaces_ether_interfaces | map(attribute='device') | list
+    - item not in interfaces_bridge_interfaces | map(attribute='device') | list
+    - item not in interfaces_bridge_interfaces | map(attribute='ports') | flatten | list
+    - item not in interfaces_bond_interfaces | map(attribute='device') | list
+    - item not in interfaces_bond_interfaces | map(attribute='bond_slaves') | flatten | list
+  with_items: "{{ interfaces_workaround_centos_remove }}"
+
 - name: RedHat | ensure network service is started and enabled
   become: true
   service:


### PR DESCRIPTION
On RHEL/CentOS 8, this role now installs the network-scripts RPM. This
RPM provides the legacy ifup / ifdown implementations that can bypass
NetworkManager. It also provides a network init.d script. However, this
script is not enabled by default.

Since we use NM_CONTROLLED=no, this means that a role invocation will
work fine, until the next reboot or until the DHCP lease expires (when
using DHCP), whichever comes first.

This change fixes the issue by enabling network.service.

Fixes: #68