### PR TITLE
Allow unmanaged addresses on an interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,26 @@ Or to avoid performing this workaround:
 interfaces_workaround_centos_remove: []
 ```
 
+10) Allowed addresses
+
+Sometimes it may be useful to not immediately assign an IP address to an
+interface, but to allow another process to assign one. An example use case is a
+virtual IP address dynamically added or by a process such as keepalived.
+This may be configured via an `allowed_addresses` field in an Ethernet, bond or
+bridge interface configuration.
+
+```yaml
+- hosts: myhost
+  roles:
+    - role: MichaelRigart.interfaces
+      interfaces_ether_interfaces:
+        - device: eth0
+          bootproto: static
+          address: 0.0.0.0
+          allowed_addresses:
+            - 10.0.0.2
+```
+
 Example Playbook
 ----------------
 

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -94,7 +94,7 @@ def _interface_check(context, interface, interface_type=None):
                 if interface["gateway"] != fact_gateway:
                     return _fail("Default IPv4 gateway is incorrect")
 
-        elif fact_address:
+        elif fact_address and fact_address not in interface.get('allowed_addresses', []):
             return _fail("Interface %s has an IPv4 address but none was "
                          "requested" % device)
     


### PR DESCRIPTION
Sometimes it may be useful to not immediately assign an IP address to an
interface, but to allow another process to assign one. An example use
case is a virtual IP address dynamically added or by a process such as
keepalived.

This change adds support for this via an 'allowed_addresses' field in
Ethernet, bond or bridge interface configuration.

Fixes: #70