### PR TITLE
Add support for custom route options

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,27 @@ bridge interface configuration.
             - 10.0.0.2
 ```
 
+11) Custom options for static routes
+
+Adding custom options to static routes is possible via the `options` attribute,
+which should be a list.
+
+```yaml
+- hosts: myhost
+  roles:
+    - role: MichaelRigart.interfaces
+      interfaces_ether_interfaces:
+        - device: eth0
+          bootproto: static
+          address: 0.0.0.0
+          route:
+           - network: 192.168.200.0
+             netmask: 255.255.255.0
+             gateway: 192.168.1.1
+             options:
+               - onlink
+               - metric 400
+
 Example Playbook
 ----------------
 

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -64,6 +64,9 @@ bond-slaves {{ item.bond_slaves|join(' ') }}
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
 {% endif %}
+{% if 'options' in i %}
+{% set route = route ~ ' ' ~ i.options | join(' ') %}
+{% endif %}
 up ip route add {{ route }}
 down ip route del {{ route }}
 {% endfor %}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -44,6 +44,9 @@ bridge_stp {{ item.stp }}
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
 {% endif %}
+{% if 'options' in i %}
+{% set route = route ~ ' ' ~ i.options | join(' ') %}
+{% endif %}
 up ip route add {{ route }}
 down ip route del {{ route }}
 {% endfor %}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -46,6 +46,9 @@ wpa-conf {{ item.wpaconf }}
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
 {% endif %}
+{% if 'options' in i %}
+{% set route = route ~ ' ' ~ i.options | join(' ') %}
+{% endif %}
 up ip route add {{ route }}
 down ip route del {{ route }}
 {% endfor %}
@@ -86,6 +89,9 @@ gateway {{ item.ip6.gateway }}
 {% endif %}
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
+{% endif %}
+{% if 'options' in i %}
+{% set route = route ~ ' ' ~ i.options | join(' ') %}
 {% endif %}
 up ip -6 route add {{ route }}
 down ip -6 route del {{ route }}

--- a/templates/route6_RedHat.j2
+++ b/templates/route6_RedHat.j2
@@ -12,6 +12,9 @@
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
 {% endif %}
+{% if 'options' in i %}
+{% set route = route ~ ' ' ~ i.options | join(' ') %}
+{% endif %}
 {{ route }}
 {% endfor %}
 {% endif %}

--- a/templates/route_RedHat.j2
+++ b/templates/route_RedHat.j2
@@ -11,5 +11,8 @@
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
 {% endif %}
+{% if 'options' in i %}
+{% set route = route ~ ' ' ~ i.options | join(' ') %}
+{% endif %}
 {{ route }}
 {% endfor %}

--- a/tests/interfaces.yml
+++ b/tests/interfaces.yml
@@ -50,6 +50,11 @@
             - network: 10.1.0.0
               netmask: 255.255.255.0
               table: myroutetable
+            - network: 10.7.0.0
+              netmask: 255.255.255.0
+              gateway: 10.1.0.2
+              options:
+                - onlink
         - device: "{{ bridge_name }}.1002"
           bootproto: static
           address: 10.2.0.1


### PR DESCRIPTION
Ethernet, bridge, and bond links now all support addition of custom
options to their static routes. The options should be specified as a
list.