### PR TITLE
Remove ifcfg-eth0 if eth0 is not present or being configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,10 +259,12 @@ systems.
 
 9) CentOS 8 cloud image workaround
 
-CentOS 8 cloud images ship with an ifcfg file for ens3. This seems to be a
-relic from the image build process, and causes the network service to fail.
-This role will by default remove this file, if there is no ens3 interface on
-the system, and no ens3 interface is specified in the role variables.
+CentOS 8 cloud images ship with ifcfg files for ens3 and eth0. ifcfg-ens3 seems
+to be a relic from the image build process, and causes the network service to
+fail. ifcfg-eth0 is useful for most virtual machines, but if a cloud image is
+deployed on bare metal and eth0 is absent, the network service will fail. This
+role will by default remove these files, if there is no such interface on the
+system, and no such interface is specified in the role variables.
 
 This workaround is configured via `interfaces_workaround_centos_remove`. To
 set a different interface file to remove:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,4 @@ interfaces_bridge_interfaces: []
 interfaces_bond_interfaces: []
 interfaces_workaround_centos_remove:
   - ens3
+  - eth0

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -6,9 +6,12 @@
     state: '{{ interfaces_pkg_state }}'
   tags: package
 
-# CentOS 8 cloud images ship with an ifcfg file for ens3. This seems to be a
-# relic from the image build process, and causes the network service to fail.
-# Remove this file.
+# CentOS 8 cloud images ship with ifcfg files for ens3 and eth0. ifcfg-ens3
+# seems to be a relic from the image build process, and causes the network
+# service to fail. ifcfg-eth0 is useful for most virtual machines, but if a
+# cloud image is deployed on bare metal and eth0 is absent, the network service
+# will fail. Remove these files if the interface does not exist or is not being
+# configured.
 
 - name: RedHat | remove invalid interface configuration
   become: true


### PR DESCRIPTION
 CentOS 8 cloud images also ship with an `ifcfg-eth0` file which can cause the network service to fail if no `eth0` interface is present or being configured.