### PR TITLE
Revert "fix conditionals in tasks/main.yml"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,13 +10,13 @@
   tags: configuration
 
 - include: 'ethernet_configuration.yml'
-  when: interfaces_ether_interfaces | length > 0
+  when: interfaces_ether_interfaces is defined
   tags: configuration
 
 - include: 'bond_configuration.yml'
-  when: interfaces_bond_interfaces | length > 0
+  when: interfaces_bond_interfaces is defined
   tags: configuration
 
 - include: 'bridge_configuration.yml'
-  when: interfaces_bridge_interfaces | length > 0
+  when: interfaces_bridge_interfaces is defined
   tags: configuration


### PR DESCRIPTION
This reverts commit a235b504413e14a6afca90cb1823d20cdc027498. We still need to include these playbooks when no interface is being configured because we need `*_interfaces_changed` variables to be defined.

Closes #82.

/cc @pescobar @markgoddard 