### PR TITLE
Reload VLAN interface on parent device change

### DIFF
--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -88,8 +88,9 @@
   notify:
     - Bounce network devices
 
-- name: Set a fact containing all ethernet results
-  set_fact:
+# ether_interfaces_changed is used in the 'Bounce network devices' handler.
+- name: Set a fact containing changed ethernet devices
+  vars:
     # Build a list of all Ethernet results.
     all_ether_results: >
       {{ ether_check_result.results | default([]) +
@@ -100,10 +101,6 @@
          ether_route6_del_result.results | default([]) +
          ether_rule_add_result.results | default([]) +
          ether_rule_del_result.results | default([]) }}
-
-# ether_interfaces_changed is used in the 'Bounce network devices' handler.
-- name: Set a fact containing changed ethernet devices
-  set_fact:
     # Select those tasks which changed, and map to a list of the corresponding
     # Ethernet devices.
     ether_interfaces_changed: >
@@ -112,3 +109,15 @@
          map(attribute='item.device') |
          unique |
          list }}
+    vlan_on_changed_interface_regex: "{{ '(' ~ ((ether_interfaces_changed + bond_master_interfaces_changed + bridge_interfaces_changed) | join('|')) ~ ')' ~ vlan_interface_suffix_regex }}"
+    # Find VLAN interfaces which have a changed parent device. At least on
+    # CentOS/RHEL 7 systems, any static routes on the VLAN interface are lost
+    # if the parent goes down.
+    vlans_on_changed_interfaces: >
+      {{ all_ether_results |
+         map(attribute='item.device') |
+         select('match', vlan_on_changed_interface_regex) |
+         unique |
+         list }}
+  set_fact:
+    ether_interfaces_changed: "{{ (ether_interfaces_changed + vlans_on_changed_interfaces) | unique | list}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,14 +9,14 @@
 - include: 'route_table_configuration.yml'
   tags: configuration
 
-- include: 'ethernet_configuration.yml'
-  when: interfaces_ether_interfaces is defined
-  tags: configuration
-
 - include: 'bond_configuration.yml'
   when: interfaces_bond_interfaces is defined
   tags: configuration
 
 - include: 'bridge_configuration.yml'
   when: interfaces_bridge_interfaces is defined
+  tags: configuration
+
+- include: 'ethernet_configuration.yml'
+  when: interfaces_ether_interfaces is defined
   tags: configuration


### PR DESCRIPTION
On CentOS/RHEL systems, if the parent device of a VLAN interface goes down, the
VLAN interface will also go down, and lose any static routes assigned to it. If
the parent device is brought back up again, the VLAN interface will become
active again, but any static routes previously assigned to the VLAN interface
are not reinstated.

This change fixes the issue by adding VLAN interfaces to the list of changed
interfaces, if their parent device is changed.

Fixes: #86