### PR TITLE
Support pausing before checking interface status

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ is not supported at this time.
            zone: trusted
  ```
 
+15) Pause to wait for interfaces to become active
+
+On some OS distributions (including Ubuntu), it may be necessary to wait after
+bouncing network interfaces before they are active. This can be done by setting
+``interfaces_pause_time`` to a number of seconds to delay.
+
 Example Playbook
 ----------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,4 @@ interfaces_workaround_centos_remove:
   - ens3
   - ens3-1
   - eth0
+interfaces_pause_time: 0

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -154,10 +154,15 @@
            bond_master_interfaces_changed }}
     all_interfaces_changed: "{{ all_interfaces_changed_map[ansible_os_family] }}"
   notify:
+    - Pause to wait for interfaces to become active
     - Gather facts
     - Check active Ethernet interface state
     - Check active bond interface state
     - Check active bridge interface state
+
+- name: Pause to wait for interfaces to become active
+  pause:
+    seconds: "{{ interfaces_pause_time }}"
 
 # Update host facts so that we can verify the configuration has been applied
 # correctly.


### PR DESCRIPTION
On some OS distributions (including Ubuntu), it may be necessary to wait
after bouncing network interfaces before they are active. This can be
done by setting ``interfaces_pause_time`` to a number of seconds to
delay. The default is not to pause.

Co-Authored-By: James Denton <@busterswt>