### PR TITLE
Added new options to configure interfaces & refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,46 @@ On some OS distributions (including Ubuntu), it may be necessary to wait after
 bouncing network interfaces before they are active. This can be done by setting
 ``interfaces_pause_time`` to a number of seconds to delay.
 
+16) Configure HW(MAC) address for interface
+
+  Configuring interface HW adrress is possible using the `hwaddr` attribute.
+  This alone may not be sufficient to change MAC from default one, however
+  specifying hw address is necessary for some systems.
+
+```yaml
+ - hosts: myhost
+   roles:
+     - role: MichaelRigart.interfaces
+       interfaces_ether_interfaces:
+         - device: eth0
+           bootproto: static
+           address: 192.168.1.150
+           netmask: 255.255.255.0
+           gateway: 192.168.1.1
+           hwaddr: 00:11:22:33:44:55
+```
+
+17) Configure HW(MAC) address for bonded/bridged interface
+
+  Configuring interface HW adrress is possible using the `hwaddr` attribute.
+
+```yaml
+- hosts: myhost
+  roles:
+    - role: MichaelRigart.interfaces
+      interfaces_bond_interfaces:
+        - device: bond0
+          bootproto: dhcp
+          bond_mode: 802.3ad
+          hwaddr: 00:11:22:33:44:55
+      interfaces_bridge_interfaces:
+       -  device: br1
+          type: bridge
+          bootproto: dhcp
+          hwaddr: 00:11:22:33:44:66
+          ports: [eth1, eth2]
+```
+
 Example Playbook
 ----------------
 

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -1,6 +1,9 @@
 # {{ ansible_managed }}
 
 auto {{ item.device }}
+{% if item.bootproto == 'dhcp' %}
+iface {{ item.device }} inet dhcp
+{% endif %}
 {% if item.bootproto == 'static' %}
 iface {{ item.device }} inet static
 {% if item.pre_up is defined %}
@@ -17,6 +20,10 @@ netmask {{ item.netmask }}
 {% endif %}
 {% if item.gateway is defined %}
 gateway {{ item.gateway }}
+{% endif %}
+{% endif %}
+{% if item.hwaddr is defined %}
+hwaddress {{ item.hwaddr }}
 {% endif %}
 {% if item.bond_mode is defined %}
 bond-mode {{ item.bond_mode }}
@@ -39,21 +46,6 @@ bond-slaves none
 {% endif %}
 {% if item.bond_slaves is defined and item.bond_mode | default == '802.3ad' %}
 bond-slaves {{ item.bond_slaves|join(' ') }}
-{% endif %}
-{% endif %}
-
-{% if item.bootproto == 'dhcp' %}
-iface {{ item.device }} inet dhcp
-{% if item.bond_mode is defined %}
-bond-mode {{ item.bond_mode }}
-{% endif %}
-bond-miimon {{ item.bond_miimon|default(100) }}
-{% if item.bond_slaves is defined and item.bond_mode | default == 'active-backup' %}
-bond-slaves none
-{% endif %}
-{% if item.bond_slaves is defined and item.bond_mode | default == '802.3ad' %}
-bond-slaves {{ item.bond_slaves|join(' ') }}
-{% endif %}
 {% endif %}
 
 {% if item.route is defined %}

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -6,12 +6,6 @@ iface {{ item.device }} inet dhcp
 {% endif %}
 {% if item.bootproto == 'static' %}
 iface {{ item.device }} inet static
-{% if item.pre_up is defined %}
-pre-up {{ item.pre_up }}
-{% endif %}
-{% if item.mtu is defined %}
-mtu {{ item.mtu }}
-{% endif %}
 {% if item.address is defined %}
 address {{ item.address }}
 {% endif %}
@@ -22,8 +16,14 @@ netmask {{ item.netmask }}
 gateway {{ item.gateway }}
 {% endif %}
 {% endif %}
+{% if item.mtu is defined %}
+mtu {{ item.mtu }}
+{% endif %}
 {% if item.hwaddr is defined %}
 hwaddress {{ item.hwaddr }}
+{% endif %}
+{% if item.pre_up is defined %}
+pre-up {{ item.pre_up }}
 {% endif %}
 {% if item.bond_mode is defined %}
 bond-mode {{ item.bond_mode }}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -18,30 +18,23 @@ NETMASK={{ item.netmask }}
 GATEWAY={{ item.gateway }}
 {% endif %}
 {% endif %}
-
 {% if item.bootproto == 'dhcp' %}
 BOOTPROTO=dhcp
 {% endif %}
-
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute | bool | ternary('yes', 'no') }}
 {% endif %}
-
-ONBOOT={{ item.onboot|default("yes") }}
+ONBOOT={{ item.onboot | bool | ternary('yes', 'no') }}
 BONDING_OPTS="{% if item.bond_mode is defined %}mode={{ item.bond_mode }} {% endif %}miimon={{ item.bond_miimon|default(100) }} {% if item.bond_updelay is defined %}updelay={{ item.bond_updelay }} {% endif %} {% if item.bond_downdelay is defined %}downdelay={{ item.bond_downdelay }} {% endif %} {% if item.bond_xmit_hash_policy is defined %}xmit_hash_policy={{ item.bond_xmit_hash_policy }} {% endif %} {% if item.bond_lacp_rate is defined %}lacp_rate={{ item.bond_lacp_rate }} {% endif %} "
-
 {% if ansible_distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
-
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}
 {% endif %}
-
 {% if item.zone is defined %}
 ZONE="{{ item.zone }}"
 {% endif %}
-
 {% for bridge in interfaces_bridge_interfaces %}
 {% if item.device in bridge.ports %}
 BRIDGE={{ bridge.device }}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -1,6 +1,10 @@
 # {{ ansible_managed }}
 
 DEVICE={{ item.device }}
+TYPE=Bond
+{% if item.hwaddr is defined %}
+HWADDR={{ item.hwaddr }}
+{% endif %}
 USERCTL=no
 {% if item.bootproto == 'static' %}
 BOOTPROTO=none

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -6,12 +6,6 @@ iface {{ item.device }} inet dhcp
 {% endif %}
 {% if item.bootproto == 'static' %}
 iface {{ item.device }} inet static
-{% if item.pre_up is defined %}
-pre-up {{ item.pre_up }}
-{% endif %}
-{% if item.mtu is defined %}
-mtu {{ item.mtu }}
-{% endif %}
 {% if item.address is defined %}
 address {{ item.address }}
 {% endif %}
@@ -22,8 +16,14 @@ netmask {{ item.netmask }}
 gateway {{ item.gateway }}
 {% endif %}
 {% endif %}
+{% if item.mtu is defined %}
+mtu {{ item.mtu }}
+{% endif %}
 {% if item.hwaddr is defined %}
 hwaddress {{ item.hwaddr }}
+{% endif %}
+{% if item.pre_up is defined %}
+pre-up {{ item.pre_up }}
 {% endif %}
 {% if item.ports is defined %}
 bridge_ports {{ item.ports|join(' ') }}{% if item.ports | default([], true) | length == 0 %}none{% endif %}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -1,6 +1,9 @@
 # {{ ansible_managed }}
 
 auto {{ item.device }}
+{% if item.bootproto == 'dhcp' %}
+iface {{ item.device }} inet dhcp
+{% endif %}
 {% if item.bootproto == 'static' %}
 iface {{ item.device }} inet static
 {% if item.pre_up is defined %}
@@ -18,22 +21,15 @@ netmask {{ item.netmask }}
 {% if item.gateway is defined %}
 gateway {{ item.gateway }}
 {% endif %}
+{% endif %}
+{% if item.hwaddr is defined %}
+hwaddress {{ item.hwaddr }}
+{% endif %}
 {% if item.ports is defined %}
 bridge_ports {{ item.ports|join(' ') }}{% if item.ports | default([], true) | length == 0 %}none{% endif %}
 {% endif %}
 {% if item.stp is defined %}
 bridge_stp {{ item.stp }}
-{% endif %}
-{% endif %}
-
-{% if item.bootproto == 'dhcp' %}
-iface {{ item.device }} inet dhcp
-{% if item.ports is defined %}
-bridge_ports {{ item.ports|join(' ') }}
-{% endif %}
-{% if item.stp is defined %}
-bridge_stp {{ item.stp }}
-{% endif %}
 {% endif %}
 
 {% if item.route is defined %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -7,9 +7,6 @@ HWADDR={{ item.hwaddr }}
 {% endif %}
 {% if item.bootproto == 'static' %}
 BOOTPROTO=none
-{% if item.stp is defined %}
-STP={{ item.stp }}
-{% endif %}
 {% if item.address is defined %}
 IPADDR={{ item.address }}
 {% endif %}
@@ -20,30 +17,24 @@ NETMASK={{ item.netmask }}
 GATEWAY={{ item.gateway }}
 {% endif %}
 {% endif %}
-
 {% if item.bootproto == 'dhcp' %}
 BOOTPROTO=dhcp
+{% endif %}
 {% if item.stp is defined %}
 STP={{ item.stp }}
 {% endif %}
-{% endif %}
-
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute | bool | ternary('yes', 'no') }}
 {% endif %}
-
 {% if item.onboot is defined %}
-ONBOOT={{ item.onboot }}
+ONBOOT={{ item.onboot | bool | ternary('yes', 'no') }}
 {% endif %}
-
 {% if ansible_distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
-
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}
 {% endif %}
-
 {% if item.zone is defined %}
 ZONE="{{ item.zone }}"
 {% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -1,8 +1,11 @@
 # {{ ansible_managed }}
 
 DEVICE={{ item.device }}
-{% if item.bootproto == 'static' %}
 TYPE=Bridge
+{% if item.hwaddr is defined %}
+HWADDR={{ item.hwaddr }}
+{% endif %}
+{% if item.bootproto == 'static' %}
 BOOTPROTO=none
 {% if item.stp is defined %}
 STP={{ item.stp }}
@@ -19,7 +22,6 @@ GATEWAY={{ item.gateway }}
 {% endif %}
 
 {% if item.bootproto == 'dhcp' %}
-TYPE=Bridge
 BOOTPROTO=dhcp
 {% if item.stp is defined %}
 STP={{ item.stp }}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -1,13 +1,13 @@
 # {{ ansible_managed }}
 
-{% if item.bootproto == 'static' %}
 {{ item.allowclass | default('auto') }} {{ item.device }}
+{% if item.bootproto == 'dhcp' %}
+iface {{ item.device }} inet dhcp
+{% endif %}
+{% if item.bootproto == 'static' %}
 iface {{ item.device }} inet static
 {% if item.pre_up is defined %}
 pre-up {{ item.pre_up }}
-{% endif %}
-{% if item.wpaconf is defined %}
-wpa-conf {{ item.wpaconf }}
 {% endif %}
 {% if item.mtu is defined %}
 mtu {{ item.mtu }}
@@ -28,15 +28,14 @@ dns-nameservers {{ item.dnsnameservers }}
 {% if item.dnssearch is defined %}
 dns-search {{ item.dnssearch }}
 {% endif %}
-{% if item.bootproto == 'dhcp' %}
-{{ item.allowclass | default('auto') }} {{ item.device }}
-iface {{ item.device }} inet dhcp
+{% if item.hwaddr is defined %}
+hwaddress ether {{ item.hwaddr }}
+{% endif %}
 {% if item.wpaconf is defined %}
 wpa-conf {{ item.wpaconf }}
 {% endif %}
-{% endif %}
-{% if item.route is defined %}
 
+{% if item.route is defined %}
 {% for i in item.route %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
 {% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -6,12 +6,6 @@ iface {{ item.device }} inet dhcp
 {% endif %}
 {% if item.bootproto == 'static' %}
 iface {{ item.device }} inet static
-{% if item.pre_up is defined %}
-pre-up {{ item.pre_up }}
-{% endif %}
-{% if item.mtu is defined %}
-mtu {{ item.mtu }}
-{% endif %}
 {% if item.address is defined %}
 address {{ item.address }}
 {% endif %}
@@ -25,11 +19,17 @@ gateway {{ item.gateway }}
 dns-nameservers {{ item.dnsnameservers }}
 {% endif %}
 {% endif %}
-{% if item.dnssearch is defined %}
-dns-search {{ item.dnssearch }}
+{% if item.mtu is defined %}
+mtu {{ item.mtu }}
 {% endif %}
 {% if item.hwaddr is defined %}
 hwaddress ether {{ item.hwaddr }}
+{% endif %}
+{% if item.pre_up is defined %}
+pre-up {{ item.pre_up }}
+{% endif %}
+{% if item.dnssearch is defined %}
+dns-search {{ item.dnssearch }}
 {% endif %}
 {% if item.wpaconf is defined %}
 wpa-conf {{ item.wpaconf }}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -1,11 +1,12 @@
 # {{ ansible_managed }}
 
 DEVICE={{ item.device }}
-{% if item.bootproto == 'static' %}
-BOOTPROTO=none
+TYPE=Ethernet
 {% if item.hwaddr is defined %}
 HWADDR={{ item.hwaddr }}
 {% endif %}
+{% if item.bootproto == 'static' %}
+BOOTPROTO=none
 {% if item.address is defined %}
 IPADDR={{ item.address }}
 {% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -3,6 +3,9 @@
 DEVICE={{ item.device }}
 {% if item.bootproto == 'static' %}
 BOOTPROTO=none
+{% if item.hwaddr is defined %}
+HWADDR={{ item.hwaddr }}
+{% endif %}
 {% if item.address is defined %}
 IPADDR={{ item.address }}
 {% endif %}
@@ -21,45 +24,39 @@ DNS{{ loop.index }}={{ dns_server }}
 DOMAIN={{ item.dnssearch }}
 {% endif %}
 {% endif %}
-
 {% if item.bootproto == 'dhcp' %}
 BOOTPROTO=dhcp
 {% endif %}
-
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute | bool | ternary('yes', 'no') }}
 {% endif %}
-
 {% if item.ethtool_opts is defined %}
 ETHTOOL_OPTS="{{ item.ethtool_opts }}"
 {% endif %}
-
 {% if item.onboot is defined %}
-ONBOOT={{ item.onboot }}
+ONBOOT={{ item.onboot | bool | ternary('yes', 'no') }}
 {% endif %}
-
 {% if ansible_distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
-
 {% if item.device is match(vlan_interface_regex) %}
 VLAN=yes
 {% endif %}
-
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}
 {% endif %}
-
 {% if item.zone is defined %}
 ZONE="{{ item.zone }}"
 {% endif %}
-
 {% if item.bootproto == 'static' %}
 {% if item.ip6 is defined %}
 IPV6INIT=yes
 IPV6ADDR={{ item.ip6.address ~ '/' ~ item.ip6.prefix }}
 {% if item.ip6.gateway is defined %}
 IPV6_DEFAULTGW={{ item.ip6.gateway }}
+{% endif %}
+{% if item.ip6.defaultdev is defined %}
+IPV6_DEFAULTDEV={{ item.ip6.defaultdev }}
 {% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Added config options:
- HWADDR
- IPV6_DEFAULTDEV

Refactored ONBOOT to evaluate bool value in similar way as DEFROUTE
` {{ item.onboot | bool | ternary('yes', 'no') }}`

Removed empty lines that were inserted into the rendered config file.