### PR TITLE
Support static DNS config on bonded interfaces

### DIFF
--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -15,6 +15,9 @@ netmask {{ item.netmask }}
 {% if item.gateway is defined %}
 gateway {{ item.gateway }}
 {% endif %}
+{% if item.dnsnameservers is defined %}
+dns-nameservers {{ item.dnsnameservers }}
+{% endif %}
 {% endif %}
 {% if item.mtu is defined %}
 mtu {{ item.mtu }}
@@ -24,6 +27,9 @@ hwaddress {{ item.hwaddr }}
 {% endif %}
 {% if item.pre_up is defined %}
 pre-up {{ item.pre_up }}
+{% endif %}
+{% if item.dnssearch is defined %}
+dns-search {{ item.dnssearch }}
 {% endif %}
 {% if item.bond_mode is defined %}
 bond-mode {{ item.bond_mode }}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -32,7 +32,9 @@ BOOTPROTO=dhcp
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute | bool | ternary('yes', 'no') }}
 {% endif %}
+{% if item.onboot is defined %}
 ONBOOT={{ item.onboot | bool | ternary('yes', 'no') }}
+{% endif %}
 BONDING_OPTS="{% if item.bond_mode is defined %}mode={{ item.bond_mode }} {% endif %}miimon={{ item.bond_miimon|default(100) }} {% if item.bond_updelay is defined %}updelay={{ item.bond_updelay }} {% endif %} {% if item.bond_downdelay is defined %}downdelay={{ item.bond_downdelay }} {% endif %} {% if item.bond_xmit_hash_policy is defined %}xmit_hash_policy={{ item.bond_xmit_hash_policy }} {% endif %} {% if item.bond_lacp_rate is defined %}lacp_rate={{ item.bond_lacp_rate }} {% endif %} "
 {% if ansible_distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -18,6 +18,14 @@ NETMASK={{ item.netmask }}
 GATEWAY={{ item.gateway }}
 {% endif %}
 {% endif %}
+{% if item.dnsnameservers is defined %}
+{% for dns_server in item.dnsnameservers.split(' ')[:2] %}
+DNS{{ loop.index }}={{ dns_server }}
+{% endfor %}
+{% endif %}
+{% if item.dnssearch is defined %}
+DOMAIN={{ item.dnssearch }}
+{% endif %}
 {% if item.bootproto == 'dhcp' %}
 BOOTPROTO=dhcp
 {% endif %}


### PR DESCRIPTION
Fixes #103.

(Also makes `onboot` optional for bonded interfaces, as it is for the others.)