### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 interfaces_pkgs:
   debian:
-    - python{% if ansible_python.version.major >= 3 %}3{% endif %}-selinux
+    - python{% if ansible_facts.python.version.major >= 3 %}3{% endif %}-selinux
     - bridge-utils
     - ifenslave
     - ifupdown

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -24,13 +24,13 @@ def _device(interface):
 def _fact_name(device):
     """Return the name of the Ansible fact associated with an interface."""
     # Ansible fact names replace dashes and colons with an underscore.
-    return "ansible_%s" % re.sub(r"[\-\:]", "_", device)
+    return re.sub(r"[\-\:]", "_", device)
 
 
 def _fact(context, device):
     """Return the fact associated with an interface."""
     fact_name = _fact_name(device)
-    return context[fact_name]
+    return context["ansible_facts"][fact_name]
 
 
 def _interface_check(context, interface, interface_type=None):
@@ -45,7 +45,7 @@ def _interface_check(context, interface, interface_type=None):
 
     # Existence
     fact_name = _fact_name(device)
-    if fact_name not in context:
+    if fact_name not in context["ansible_facts"]:
         return _fail("Interface %s does not exist" % device)
 
     fact = _fact(context, device)
@@ -88,7 +88,7 @@ def _interface_check(context, interface, interface_type=None):
 
             # Gateway
             if interface.get("gateway"):
-                fact_gateway = context.get("ansible_default_ipv4", {}).get("gateway")
+                fact_gateway = context["ansible_facts"].get("default_ipv4", {}).get("gateway")
                 if not fact_gateway:
                     return _fail("Default IPv4 gateway is missing")
                 if interface["gateway"] != fact_gateway:
@@ -113,7 +113,7 @@ def _interface_check(context, interface, interface_type=None):
         
         # Gateway
         if interface["ip6"].get("gateway"):
-            fact_gateway = context.get("ansible_default_ipv6", {}).get("gateway")
+            fact_gateway = context["ansible_facts"].get("default_ipv6", {}).get("gateway")
             if not fact_gateway:
                 return _fail("Default IPv6 gateway is missing")
             if interface["ip6"]["gateway"] != fact_gateway:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -113,11 +113,11 @@
     nohup bash -c "
     returncode=0
     {% for interface in all_interfaces_changed | reverse %}
-    ifdown {% if ansible_os_family == 'Debian' %}--allow auto {% endif %}{{ interface }};
+    ifdown {% if ansible_facts.os_family == 'Debian' %}--allow auto {% endif %}{{ interface }};
     {% endfor %}
 
     {% for interface in all_interfaces_changed %}
-    if ! ifup {% if ansible_os_family == 'Debian' %}--allow auto {% endif %}{{ interface }}; then
+    if ! ifup {% if ansible_facts.os_family == 'Debian' %}--allow auto {% endif %}{{ interface }}; then
       echo \"Failed to bring up interface {{ interface }}\";
       returncode=1
     fi;
@@ -152,7 +152,7 @@
            bond_slave_interfaces_changed +
            ether_vlan_interfaces_changed +
            bond_master_interfaces_changed }}
-    all_interfaces_changed: "{{ all_interfaces_changed_map[ansible_os_family] }}"
+    all_interfaces_changed: "{{ all_interfaces_changed_map[ansible_facts.os_family] }}"
   notify:
     - Pause to wait for interfaces to become active
     - Gather facts

--- a/tasks/bond_configuration.yml
+++ b/tasks/bond_configuration.yml
@@ -16,8 +16,8 @@
 - name: Create the network configuration file for bond devices
   become: true
   template:
-    src: 'bond_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/ifcfg-{{ item.device }}'
+    src: 'bond_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/ifcfg-{{ item.device }}'
   with_items: '{{ interfaces_bond_interfaces }}'
   register: bond_result
   notify:
@@ -30,10 +30,10 @@
 - name: RedHat | Write configuration files for rhel route configuration
   become: true
   template:
-    src: 'route_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
+    src: 'route_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
   with_items: '{{ interfaces_bond_interfaces }}'
-  when: item.route is defined and ansible_os_family == 'RedHat'
+  when: item.route is defined and ansible_facts.os_family == 'RedHat'
   register: bond_route_add_result
   notify:
     - Bounce network devices
@@ -41,10 +41,10 @@
 - name: RedHat | Remove configuration files for rhel route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
+    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bond_interfaces }}'
-  when: item.route is not defined and ansible_os_family == 'RedHat'
+  when: item.route is not defined and ansible_facts.os_family == 'RedHat'
   register: bond_route_del_result
   notify:
     - Bounce network devices
@@ -52,10 +52,10 @@
 - name: RedHat | Write configuration files for rhel rule configuration
   become: true
   template:
-    src: 'rule_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
+    src: 'rule_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
   with_items: '{{ interfaces_bond_interfaces }}'
-  when: item.rules is defined and ansible_os_family == 'RedHat'
+  when: item.rules is defined and ansible_facts.os_family == 'RedHat'
   register: bond_rule_add_result
   notify:
     - Bounce network devices
@@ -63,10 +63,10 @@
 - name: RedHat | Remove configuration files for rhel rule configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
+    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bond_interfaces }}'
-  when: item.rules is not defined and ansible_os_family == 'RedHat'
+  when: item.rules is not defined and ansible_facts.os_family == 'RedHat'
   register: bond_rule_del_result
   notify:
     - Bounce network devices
@@ -74,8 +74,8 @@
 - name: Create the network configuration file for slave in the bond devices
   become: true
   template:
-    src: 'bond_slave_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/ifcfg-{{ item.1 }}'
+    src: 'bond_slave_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/ifcfg-{{ item.1 }}'
   with_subelements:
     - "{{ interfaces_bond_interfaces }}"
     - bond_slaves

--- a/tasks/bridge_configuration.yml
+++ b/tasks/bridge_configuration.yml
@@ -15,8 +15,8 @@
 - name: Create the network configuration file for bridge devices
   become: true
   template:
-    src: 'bridge_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/ifcfg-{{ item.device }}'
+    src: 'bridge_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/ifcfg-{{ item.device }}'
   with_items: '{{ interfaces_bridge_interfaces }}'
   register: bridge_result
   notify:
@@ -25,10 +25,10 @@
 - name: RedHat | Write configuration files for rhel route configuration
   become: true
   template:
-    src: 'route_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
+    src: 'route_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
   with_items: '{{ interfaces_bridge_interfaces }}'
-  when: item.route is defined and ansible_os_family == 'RedHat'
+  when: item.route is defined and ansible_facts.os_family == 'RedHat'
   register: bridge_route_add_result
   notify:
     - Bounce network devices
@@ -36,10 +36,10 @@
 - name: RedHat | Remove configuration files for rhel route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
+    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bridge_interfaces }}'
-  when: item.route is not defined and ansible_os_family == 'RedHat'
+  when: item.route is not defined and ansible_facts.os_family == 'RedHat'
   register: bridge_route_del_result
   notify:
     - Bounce network devices
@@ -47,10 +47,10 @@
 - name: RedHat | Write configuration files for rhel rule configuration
   become: true
   template:
-    src: 'rule_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
+    src: 'rule_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
   with_items: '{{ interfaces_bridge_interfaces }}'
-  when: item.rules is defined and ansible_os_family == 'RedHat'
+  when: item.rules is defined and ansible_facts.os_family == 'RedHat'
   register: bridge_rule_add_result
   notify:
     - Bounce network devices
@@ -58,10 +58,10 @@
 - name: RedHat | Remove configuration files for rhel rule configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
+    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bridge_interfaces }}'
-  when: item.rules is not defined and ansible_os_family == 'RedHat'
+  when: item.rules is not defined and ansible_facts.os_family == 'RedHat'
   register: bridge_rule_del_result
   notify:
     - Bounce network devices
@@ -69,8 +69,8 @@
 - name: Create the network configuration file for port on the bridge devices
   become: true
   template:
-    src: 'bridge_port_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/ifcfg-{{ item.1 }}'
+    src: 'bridge_port_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/ifcfg-{{ item.1 }}'
   with_subelements:
     - "{{ interfaces_bridge_interfaces }}"
     - ports

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -45,6 +45,6 @@
 - name: Debian | Create the directory for interface cfg files
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_os_family|lower] }}'
+    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}'
     state: directory
   tags: configuration

--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -15,8 +15,8 @@
 - name: Create the network configuration file for ethernet devices
   become: true
   template:
-    src: 'ethernet_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/ifcfg-{{ item.device }}'
+    src: 'ethernet_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/ifcfg-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
   register: ether_result
   notify:
@@ -25,10 +25,10 @@
 - name: RedHat | Write configuration files for rhel route configuration
   become: true
   template:
-    src: 'route_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
+    src: 'route_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.route is defined and ansible_os_family == 'RedHat'
+  when: item.route is defined and ansible_facts.os_family == 'RedHat'
   register: ether_route_add_result
   notify:
     - Bounce network devices
@@ -36,10 +36,10 @@
 - name: RedHat | Write configuration files for rhel v6 route configuration
   become: true
   template:
-    src: 'route6_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/route6-{{ item.device }}'
+    src: 'route6_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route6-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.ip6 is defined and item.ip6.route is defined and ansible_os_family == 'RedHat'
+  when: item.ip6 is defined and item.ip6.route is defined and ansible_facts.os_family == 'RedHat'
   register: ether_route6_add_result
   notify:
     - Bounce network devices
@@ -47,10 +47,10 @@
 - name: RedHat | Remove configuration files for rhel route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_os_family|lower] }}/route-{{ item.device }}'
+    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.route is not defined and ansible_os_family == 'RedHat'
+  when: item.route is not defined and ansible_facts.os_family == 'RedHat'
   register: ether_route_del_result
   notify:
     - Bounce network devices
@@ -58,10 +58,10 @@
 - name: RedHat | Remove configuration files for rhel v6 route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_os_family|lower] }}/route6-{{ item.device }}'
+    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route6-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.ip6 is not defined and ansible_os_family == 'RedHat'
+  when: item.ip6 is not defined and ansible_facts.os_family == 'RedHat'
   register: ether_route6_del_result
   notify:
     - Bounce network devices
@@ -69,10 +69,10 @@
 - name: RedHat | Write configuration files for rhel rule configuration
   become: true
   template:
-    src: 'rule_{{ ansible_os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
+    src: 'rule_{{ ansible_facts.os_family }}.j2'
+    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.rules is defined and ansible_os_family == 'RedHat'
+  when: item.rules is defined and ansible_facts.os_family == 'RedHat'
   register: ether_rule_add_result
   notify:
     - Bounce network devices
@@ -80,10 +80,10 @@
 - name: RedHat | Remove configuration files for rhel rule configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_os_family|lower] }}/rule-{{ item.device }}'
+    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.rules is not defined and ansible_os_family == 'RedHat'
+  when: item.rules is not defined and ansible_facts.os_family == 'RedHat'
   register: ether_rule_del_result
   notify:
     - Bounce network devices

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
 - include: 'debian.yml'
-  when: ansible_os_family == 'Debian'
+  when: ansible_facts.os_family == 'Debian'
 
 - include: 'redhat.yml'
-  when: ansible_os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat'
 
 - include: 'route_table_configuration.yml'
   tags: configuration

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -2,7 +2,7 @@
 - name: RedHat | install current/latest network packages versions
   become: true
   package:
-    name: '{{  interfaces_pkgs["redhat"][ansible_distribution_major_version] }}'
+    name: '{{  interfaces_pkgs["redhat"][ansible_facts.distribution_major_version] }}'
     state: '{{ interfaces_pkg_state }}'
   tags: package
 
@@ -19,7 +19,7 @@
     path: "/etc/sysconfig/network-scripts/ifcfg-{{ item }}"
     state: absent
   when:
-    - item not in ansible_interfaces
+    - item not in ansible_facts.interfaces
     - item not in interfaces_ether_interfaces | map(attribute='device') | list
     - item not in interfaces_bridge_interfaces | map(attribute='device') | list
     - item not in interfaces_bridge_interfaces | map(attribute='ports') | flatten | list

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -28,7 +28,7 @@ DEFROUTE={{ item.defroute | bool | ternary('yes', 'no') }}
 ONBOOT={{ item.onboot | bool | ternary('yes', 'no') }}
 {% endif %}
 BONDING_OPTS="{% if item.bond_mode is defined %}mode={{ item.bond_mode }} {% endif %}miimon={{ item.bond_miimon|default(100) }} {% if item.bond_updelay is defined %}updelay={{ item.bond_updelay }} {% endif %} {% if item.bond_downdelay is defined %}downdelay={{ item.bond_downdelay }} {% endif %} {% if item.bond_xmit_hash_policy is defined %}xmit_hash_policy={{ item.bond_xmit_hash_policy }} {% endif %} {% if item.bond_lacp_rate is defined %}lacp_rate={{ item.bond_lacp_rate }} {% endif %} "
-{% if ansible_distribution_major_version | int >= 7 %}
+{% if ansible_facts.distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
 {% if item.mtu is defined %}

--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -15,6 +15,6 @@ ETHTOOL_OPTS="{{ item.0.ethtool_opts }}"
 VLAN=yes
 {% endif %}
 
-{% if ansible_distribution_major_version | int >= 7 %}
+{% if ansible_facts.distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -29,7 +29,7 @@ DEFROUTE={{ item.defroute | bool | ternary('yes', 'no') }}
 {% if item.onboot is defined %}
 ONBOOT={{ item.onboot | bool | ternary('yes', 'no') }}
 {% endif %}
-{% if ansible_distribution_major_version | int >= 7 %}
+{% if ansible_facts.distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
 {% if item.mtu is defined %}

--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -13,7 +13,7 @@ ETHTOOL_OPTS="{{ item.0.ethtool_opts }}"
 ONBOOT={{ item.0.onboot }}
 {% endif %}
 
-{% if ansible_distribution_major_version | int >= 7 %}
+{% if ansible_facts.distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
 

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -37,7 +37,7 @@ ETHTOOL_OPTS="{{ item.ethtool_opts }}"
 {% if item.onboot is defined %}
 ONBOOT={{ item.onboot | bool | ternary('yes', 'no') }}
 {% endif %}
-{% if ansible_distribution_major_version | int >= 7 %}
+{% if ansible_facts.distribution_major_version | int >= 7 %}
 NM_CONTROLLED=no
 {% endif %}
 {% if item.device is match(vlan_interface_regex) %}


### PR DESCRIPTION
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars