### PR TITLE
Make setup module arguments configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ interfaces_bridge_interfaces: []
 
 # The list of bonded interfaces to be added to the system
 interfaces_bond_interfaces: []
+
+# An optional filter parameter to pass to the setup module.
+interfaces_setup_filter: "{{ omit }}"
+
+# An optional gather_subset parameter to pass to the setup module.
+interfaces_setup_gather_subset: "{{ omit }}"
 ```
 
 Note: The values for the list are listed in the examples below.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,3 +31,5 @@ interfaces_workaround_centos_remove:
   - ens3-1
   - eth0
 interfaces_pause_time: 0
+interfaces_setup_filter: "{{ omit }}"
+interfaces_setup_gather_subset: "{{ omit }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -168,6 +168,8 @@
 # correctly.
 - name: Gather facts
   setup:
+    filter: "{{ interfaces_setup_filter }}"
+    gather_subset: "{{ interfaces_setup_gather_subset }}"
 
 - name: Check active Ethernet interface state
   fail:


### PR DESCRIPTION
This role gathers facts during a handler task. Sometimes we may want to
provide arguments to the setup module to configure which facts are
gathered. This change makes the filter and gather_subset arguments
configurable.