### PR TITLE
CentOS: remove stale interfaces

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -19,7 +19,6 @@
     path: "/etc/sysconfig/network-scripts/ifcfg-{{ item }}"
     state: absent
   when:
-    - item not in ansible_facts.interfaces
     - item not in interfaces_ether_interfaces | map(attribute='device') | list
     - item not in interfaces_bridge_interfaces | map(attribute='device') | list
     - item not in interfaces_bridge_interfaces | map(attribute='ports') | flatten | list


### PR DESCRIPTION
This change allow to remove all interfaces provided in
interfaces_workaround_centos_remove variable.

Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>