### PR TITLE
RedHat: move network service start after interface config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,6 @@
 - import_tasks: 'ethernet_configuration.yml'
   when: interfaces_ether_interfaces is defined
   tags: configuration
+
+- import_tasks: 'service.yml'
+  tags: service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,22 +1,18 @@
 ---
 
-- include: 'debian.yml'
-  when: ansible_facts.os_family == 'Debian'
+- include_tasks: "{{ ansible_facts.os_family | lower }}.yml"
 
-- include: 'redhat.yml'
-  when: ansible_facts.os_family == 'RedHat'
-
-- include: 'route_table_configuration.yml'
+- import_tasks: 'route_table_configuration.yml'
   tags: configuration
 
-- include: 'bond_configuration.yml'
+- import_tasks: 'bond_configuration.yml'
   when: interfaces_bond_interfaces is defined
   tags: configuration
 
-- include: 'bridge_configuration.yml'
+- import_tasks: 'bridge_configuration.yml'
   when: interfaces_bridge_interfaces is defined
   tags: configuration
 
-- include: 'ethernet_configuration.yml'
+- import_tasks: 'ethernet_configuration.yml'
   when: interfaces_ether_interfaces is defined
   tags: configuration

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -26,10 +26,3 @@
     - item not in interfaces_bond_interfaces | map(attribute='device') | list
     - item not in interfaces_bond_interfaces | map(attribute='bond_slaves') | flatten | list
   with_items: "{{ interfaces_workaround_centos_remove }}"
-
-- name: RedHat | ensure network service is started and enabled
-  become: true
-  service:
-    name: network
-    enabled: true
-    state: started

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,0 +1,13 @@
+---
+# NOTE: start the network service after configuring interfaces. This may result
+# in some interfaces being bounced again in handlers, but avoids issues where
+# the initial network configuration is invalid, preventing the service from
+# starting.
+
+- name: RedHat | ensure network service is started and enabled
+  become: true
+  service:
+    name: network
+    enabled: true
+    state: started
+  when: ansible_facts.os_family == 'RedHat'


### PR DESCRIPTION
The CentOS cloud images may include network interface files used when the image was built, which may be invalid. This role already has a workaround to remove them. It only removes files for interfaces that are not managed by this role. This ensures that the role is idempotent. However, if an invalid interface file exists for an interface that is managed by this role, it may prevent the network service from starting, resulting in Ansible failing in the following task:

```   
RedHat | ensure network service is started and enabled
```
 
This change moves the start of the network service after configuring interfaces. This should overwrite any invalid configuration files of interfaces managed by this role. This may result in some interfaces being bounced again in handlers.