### PR TITLE
Revert "CentOS: remove stale interfaces"

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -19,6 +19,7 @@
     path: "/etc/sysconfig/network-scripts/ifcfg-{{ item }}"
     state: absent
   when:
+    - item not in ansible_facts.interfaces
     - item not in interfaces_ether_interfaces | map(attribute='device') | list
     - item not in interfaces_bridge_interfaces | map(attribute='device') | list
     - item not in interfaces_bridge_interfaces | map(attribute='ports') | flatten | list


### PR DESCRIPTION
This reverts commit bc2dd723d708b9cfca5ac0b99d6bdac0bdebba00.

This was found to cause issues, since configuration for active
interfaces could be removed and not recreated, if not present in the
network interface variables.

We should find a way to achieve the aims of this change in a different
way.

Fixes #121