### PR TITLE
dhclient is required for bootproto dhcp

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ interfaces_pkgs:
       - iproute
       - iputils
     '8':
+      - dhcp-client
       - iproute
       - iputils
       - network-scripts


### PR DESCRIPTION
The legacy network-scripts for el8 systems require dhclient when
setting bootproto to dhcp