### PR TITLE
Be able to setup bond and bridge

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,4 @@ interfaces_workaround_centos_remove:
 interfaces_pause_time: 0
 interfaces_setup_filter: "{{ omit }}"
 interfaces_setup_gather_subset: "{{ omit }}"
+interfaces_bond_setup_slaves: true

--- a/tasks/bond_configuration.yml
+++ b/tasks/bond_configuration.yml
@@ -79,6 +79,7 @@
   with_subelements:
     - "{{ interfaces_bond_interfaces }}"
     - bond_slaves
+  when: interfaces_bond_setup_slaves
   register: bond_slave_result
   notify:
     - Bounce network devices

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -38,6 +38,9 @@ bond-miimon {{ item.bond_miimon|default(100) }}
 {% if item.bond_lacp_rate is defined %}
 bond-lacp-rate {{ item.bond_lacp_rate }}
 {% endif %}
+{% if item.bond_min_links is defined %}
+bond-min-links {{ item.bond_min_links }}
+{% endif %}
 {% if item.bond_downdelay is defined %}
 bond-downdelay {{ item.bond_downdelay }}
 {% endif %}

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -1,6 +1,9 @@
 # {{ ansible_managed }}
 
 auto {{ item.device }}
+{% if item.bootproto == 'manual' %}
+iface {{ item.device }} inet manual
+{% endif %}
 {% if item.bootproto == 'dhcp' %}
 iface {{ item.device }} inet dhcp
 {% endif %}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -35,6 +35,9 @@ bridge_stp {{ item.stp }}
 {% if item.fd is defined %}
 bridge_fd {{ item.fd }}
 {% endif %}
+{% if item.vlan_aware is defined %}
+bridge-vlan-aware {{ item.vlan_aware }}
+{% endif %}
 
 {% if item.route is defined %}
 {% for i in item.route %}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -32,6 +32,9 @@ bridge_ports {{ item.ports|join(' ') }}{% if item.ports | default([], true) | le
 {% if item.stp is defined %}
 bridge_stp {{ item.stp }}
 {% endif %}
+{% if item.fd is defined %}
+bridge_fd {{ item.fd }}
+{% endif %}
 
 {% if item.route is defined %}
 {% for i in item.route %}


### PR DESCRIPTION
I would like to be able to setup bond and bridge but it's not possible actually.

Here is my yaml config file I would like to be able to use:
```yaml
interfaces_bond_interfaces:
  - device: bond0
    bootproto: manual
    bond_mode: 802.3ad
    bond_miimon: 100
    bond_lacp_rate: 1
    bond_min_links: 1
    bond_xmit_hash_policy: layer3+4
    bond_slaves: [eno5, ens1f0]

interfaces_bridge_interfaces:
  - device: vmbr0
    type: bridge
    address: 192.168.56.147
    netmask: 255.255.255.0
    gateway: 192.168.56.1
    bootproto: static
    stp: "off"
    mtu: 1500
    ports: [bond0]
    fd: 0
    bridge-vlan-aware: "yes"
```