### PR TITLE
Remove "ether" type from bond_check on slave devices

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -231,7 +231,7 @@ def bond_check(context, interface):
 
     for slave in interface_slaves:
         slave_interface = {"device": slave}
-        result = _interface_check(context, slave_interface, "ether")
+        result = _interface_check(context, slave_interface)
         if result["diff"]:
             return result
 


### PR DESCRIPTION
This addresses issue #134 