### PR TITLE
Networkmanager

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+interfaces_use_networkmanager: "{{ ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version | int >= 9 }}"
 
 interfaces_pkgs:
   debian:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,28 +1,6 @@
 ---
 interfaces_use_networkmanager: "{{ ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version | int >= 9 }}"
 
-interfaces_pkgs:
-  debian:
-    - python{% if ansible_facts.python.version.major >= 3 %}3{% endif %}-selinux
-    - bridge-utils
-    - ifenslave
-    - ifupdown
-    - iproute2
-    - resolvconf
-  redhat:
-    '7':
-      - libselinux-python
-      - bridge-utils
-      - iproute
-      - iputils
-    '8':
-      - dhcp-client
-      - iproute
-      - iputils
-      - network-scripts
-interfaces_net_path:
-  debian: /etc/network/interfaces.d
-  redhat: /etc/sysconfig/network-scripts
 interfaces_pkg_state: present
 interfaces_route_tables: []
 interfaces_ether_interfaces: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 interfaces_use_networkmanager: "{{ ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version | int >= 9 }}"
+interfaces_use_nmconnection: "{{ ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version | int >= 9 }}"
 
 interfaces_pkg_state: present
 interfaces_route_tables: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -150,6 +150,14 @@
     - Check active bond interface state
     - Check active bridge interface state
 
+# The order handlers execute are based on the order they're arranged here.
+# We want to do a controlled bounce of interfaces before we do any restart.
+- name: Restart NetworkManager
+  become: true
+  service:
+    name: NetworkManager
+    state: restarted
+
 - name: Bounce network devices
   become: true
   command: >

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -106,6 +106,12 @@
 # argument to "ifup/ifdown" will only be effective for interfaces marked with
 # "auto". Interfaces marked with "allow-hotplug" will simply be ignored then.
 #
+# Note on Network Manager Bounce mechanism:
+#
+# 'nmcli connection up' works asynchronously so we need to check if interfaces
+# are truly up, as gathering facts in next step would fail due to inactive
+# state. Running another loop to check that.
+# Dummy interfaces can have UNKNOWN state.
 
 - name: Bounce networkmanager devices
   become: true
@@ -124,6 +130,31 @@
       returncode=1
     fi;
     {% endfor %}
+
+    echo 'Waiting for interfaces to become active and have a connected carrier';
+    for i in {1..20}; do
+      all_connected=true
+      {% for interface in all_interfaces_changed %}
+      if [[ '{{ interface }}' == *dummy* ]]; then
+        allowed_states='UNKNOWN|UP'
+      else
+        allowed_states='UP'
+      fi
+
+      if ! (nmcli -t -f DEVICE,STATE device status | grep -q -w '{{ interface }}:connected' && ip link show '{{ interface }}' | grep -q -E 'state ('$allowed_states')'); then
+        all_connected=false
+        if [ $i -eq 20 ]; then
+          echo 'Interface {{ interface }} failed to become active and have a connected carrier';
+          returncode=1
+        fi
+      fi;
+      {% endfor %}
+
+      if $all_connected; then
+        break;
+      fi
+      sleep 2;
+    done
 
     exit $returncode"
   vars:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -109,9 +109,46 @@
 
 - name: Bounce networkmanager devices
   become: true
-  command: nohup nmcli connection reload
+  command: >
+    nohup bash -c "
+    nmcli connection reload;
+
+    returncode=0
+    {% for interface in all_interfaces_changed | reverse %}
+    nmcli connection down {{ interface }};
+    {% endfor %}
+
+    {% for interface in all_interfaces_changed %}
+    if ! nmcli connection up {{ interface }}; then
+      echo \"Failed to bring up interface {{ interface }}\";
+      returncode=1
+    fi;
+    {% endfor %}
+
+    exit $returncode"
+  vars:
+    ether_vlan_interfaces_changed: >
+      {{ ether_interfaces_changed | select('match', vlan_interface_regex) | list}}
+    ether_non_vlan_interfaces_changed: >
+      {{ ether_interfaces_changed | reject('match', vlan_interface_regex) | list }}
+    bridge_port_vlan_interfaces_changed: >
+      {{ bridge_port_interfaces_changed | select('match', vlan_interface_regex) | list}}
+    bridge_port_non_vlan_interfaces_changed: >
+      {{ bridge_port_interfaces_changed | reject('match', vlan_interface_regex) | list }}
+    all_interfaces_changed: >
+        {{ ether_non_vlan_interfaces_changed +
+           bridge_interfaces_changed +
+           bond_master_interfaces_changed +
+           bridge_port_interfaces_changed +
+           bond_slave_interfaces_changed +
+           ether_vlan_interfaces_changed }}
   listen: Bounce network devices
   when: interfaces_use_networkmanager
+  notify:
+    - Gather facts
+    - Check active Ethernet interface state
+    - Check active bond interface state
+    - Check active bridge interface state
 
 - name: Bounce network devices
   become: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -107,6 +107,12 @@
 # "auto". Interfaces marked with "allow-hotplug" will simply be ignored then.
 #
 
+- name: Bounce networkmanager devices
+  become: true
+  command: nohup nmcli connection reload
+  listen: Bounce network devices
+  when: interfaces_use_networkmanager
+
 - name: Bounce network devices
   become: true
   command: >
@@ -153,6 +159,7 @@
            ether_vlan_interfaces_changed +
            bond_master_interfaces_changed }}
     all_interfaces_changed: "{{ all_interfaces_changed_map[ansible_facts.os_family] }}"
+  when: not interfaces_use_networkmanager
   notify:
     - Pause to wait for interfaces to become active
     - Gather facts

--- a/tasks/bond_configuration.yml
+++ b/tasks/bond_configuration.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Check active bond interface state
   debug:
     msg: >
@@ -33,7 +32,9 @@
     src: 'route_{{ ansible_facts.os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
   with_items: '{{ interfaces_bond_interfaces }}'
-  when: item.route is defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.route is defined
+    - ansible_facts.os_family == 'RedHat'
   register: bond_route_add_result
   notify:
     - Bounce network devices
@@ -44,7 +45,9 @@
     path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bond_interfaces }}'
-  when: item.route is not defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.route is not defined
+    - ansible_facts.os_family == 'RedHat'
   register: bond_route_del_result
   notify:
     - Bounce network devices
@@ -55,7 +58,9 @@
     src: 'rule_{{ ansible_facts.os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
   with_items: '{{ interfaces_bond_interfaces }}'
-  when: item.rules is defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.rules is defined
+    - ansible_facts.os_family == 'RedHat'
   register: bond_rule_add_result
   notify:
     - Bounce network devices
@@ -66,7 +71,9 @@
     path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bond_interfaces }}'
-  when: item.rules is not defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.rules is not defined
+    - ansible_facts.os_family == 'RedHat'
   register: bond_rule_del_result
   notify:
     - Bounce network devices
@@ -79,7 +86,8 @@
   with_subelements:
     - "{{ interfaces_bond_interfaces }}"
     - bond_slaves
-  when: interfaces_bond_setup_slaves
+  when:
+    - interfaces_bond_setup_slaves
   register: bond_slave_result
   notify:
     - Bounce network devices

--- a/tasks/bond_configuration.yml
+++ b/tasks/bond_configuration.yml
@@ -16,7 +16,7 @@
   become: true
   template:
     src: 'bond_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/ifcfg-{{ item.device }}'
+    dest: '{{ interfaces_net_path }}/ifcfg-{{ item.device }}'
   with_items: '{{ interfaces_bond_interfaces }}'
   register: bond_result
   notify:
@@ -30,7 +30,7 @@
   become: true
   template:
     src: 'route_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
+    dest: '{{ interfaces_net_path }}/route-{{ item.device }}'
   with_items: '{{ interfaces_bond_interfaces }}'
   when:
     - item.route is defined
@@ -42,7 +42,7 @@
 - name: RedHat | Remove configuration files for rhel route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
+    path: '{{ interfaces_net_path }}/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bond_interfaces }}'
   when:
@@ -56,7 +56,7 @@
   become: true
   template:
     src: 'rule_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
+    dest: '{{ interfaces_net_path }}/rule-{{ item.device }}'
   with_items: '{{ interfaces_bond_interfaces }}'
   when:
     - item.rules is defined
@@ -68,7 +68,7 @@
 - name: RedHat | Remove configuration files for rhel rule configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
+    path: '{{ interfaces_net_path }}/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bond_interfaces }}'
   when:
@@ -82,7 +82,7 @@
   become: true
   template:
     src: 'bond_slave_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/ifcfg-{{ item.1 }}'
+    dest: '{{ interfaces_net_path }}/ifcfg-{{ item.1 }}'
   with_subelements:
     - "{{ interfaces_bond_interfaces }}"
     - bond_slaves

--- a/tasks/bond_configuration.yml
+++ b/tasks/bond_configuration.yml
@@ -44,7 +44,7 @@
 - name: RedHat | Remove configuration files for rhel route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path }}/route-{{ item.device }}'
+    path: '/etc/sysconfig/network-scripts/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bond_interfaces }}'
   when:
@@ -71,7 +71,7 @@
 - name: RedHat | Remove configuration files for rhel rule configuration
   become: true
   file:
-    path: '{{ interfaces_net_path }}/rule-{{ item.device }}'
+    path: '/etc/sysconfig/network-scripts/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bond_interfaces }}'
   when:

--- a/tasks/bond_configuration.yml
+++ b/tasks/bond_configuration.yml
@@ -15,8 +15,9 @@
 - name: Create the network configuration file for bond devices
   become: true
   template:
-    src: 'bond_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path }}/ifcfg-{{ item.device }}'
+    src: "bond_{{ interfaces_use_nmconnection | ternary('nmconnection', ansible_facts.os_family) }}.j2"
+    dest: "{{ interfaces_net_path }}/{{ interfaces_use_nmconnection | ternary(item.device ~ '.nmconnection', 'ifcfg-' ~ item.device) }}"
+    mode: "{{ interfaces_use_nmconnection | ternary('0600', omit) }}"
   with_items: '{{ interfaces_bond_interfaces }}'
   register: bond_result
   notify:
@@ -35,6 +36,7 @@
   when:
     - item.route is defined
     - ansible_facts.os_family == 'RedHat'
+    - not interfaces_use_nmconnection
   register: bond_route_add_result
   notify:
     - Bounce network devices
@@ -46,7 +48,7 @@
     state: absent
   with_items: '{{ interfaces_bond_interfaces }}'
   when:
-    - item.route is not defined
+    - item.route is not defined or interfaces_use_nmconnection
     - ansible_facts.os_family == 'RedHat'
   register: bond_route_del_result
   notify:
@@ -61,6 +63,7 @@
   when:
     - item.rules is defined
     - ansible_facts.os_family == 'RedHat'
+    - not interfaces_use_nmconnection
   register: bond_rule_add_result
   notify:
     - Bounce network devices
@@ -72,7 +75,7 @@
     state: absent
   with_items: '{{ interfaces_bond_interfaces }}'
   when:
-    - item.rules is not defined
+    - item.rules is not defined or interfaces_use_nmconnection
     - ansible_facts.os_family == 'RedHat'
   register: bond_rule_del_result
   notify:
@@ -81,8 +84,9 @@
 - name: Create the network configuration file for slave in the bond devices
   become: true
   template:
-    src: 'bond_slave_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path }}/ifcfg-{{ item.1 }}'
+    src: "bond_slave_{{ interfaces_use_nmconnection | ternary('nmconnection', ansible_facts.os_family) }}.j2"
+    dest: "{{ interfaces_net_path }}/{{ interfaces_use_nmconnection | ternary(item.1 ~ '.nmconnection', 'ifcfg-' ~ item.1) }}"
+    mode: "{{ interfaces_use_nmconnection | ternary('0600', omit) }}"
   with_subelements:
     - "{{ interfaces_bond_interfaces }}"
     - bond_slaves

--- a/tasks/bridge_configuration.yml
+++ b/tasks/bridge_configuration.yml
@@ -40,7 +40,7 @@
 - name: RedHat | Remove configuration files for rhel route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path }}/route-{{ item.device }}'
+    path: '/etc/sysconfig/network-scripts/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bridge_interfaces }}'
   when:
@@ -67,7 +67,7 @@
 - name: RedHat | Remove configuration files for rhel rule configuration
   become: true
   file:
-    path: '{{ interfaces_net_path }}/rule-{{ item.device }}'
+    path: '/etc/sysconfig/network-scripts/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bridge_interfaces }}'
   when:

--- a/tasks/bridge_configuration.yml
+++ b/tasks/bridge_configuration.yml
@@ -15,8 +15,9 @@
 - name: Create the network configuration file for bridge devices
   become: true
   template:
-    src: 'bridge_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path }}/ifcfg-{{ item.device }}'
+    src: "bridge_{{ interfaces_use_nmconnection | ternary('nmconnection', ansible_facts.os_family) }}.j2"
+    dest: "{{ interfaces_net_path }}/{{ interfaces_use_nmconnection | ternary(item.device ~ '.nmconnection', 'ifcfg-' ~ item.device) }}"
+    mode: "{{ interfaces_use_nmconnection | ternary('0600', omit) }}"
   with_items: '{{ interfaces_bridge_interfaces }}'
   register: bridge_result
   notify:
@@ -31,6 +32,7 @@
   when:
     - item.route is defined
     - ansible_facts.os_family == 'RedHat'
+    - not interfaces_use_nmconnection
   register: bridge_route_add_result
   notify:
     - Bounce network devices
@@ -42,7 +44,7 @@
     state: absent
   with_items: '{{ interfaces_bridge_interfaces }}'
   when:
-    - item.route is not defined
+    - item.route is not defined or interfaces_use_nmconnection
     - ansible_facts.os_family == 'RedHat'
   register: bridge_route_del_result
   notify:
@@ -57,6 +59,7 @@
   when:
     - item.rules is defined
     - ansible_facts.os_family == 'RedHat'
+    - not interfaces_use_nmconnection
   register: bridge_rule_add_result
   notify:
     - Bounce network devices
@@ -68,7 +71,7 @@
     state: absent
   with_items: '{{ interfaces_bridge_interfaces }}'
   when:
-    - item.rules is not defined
+    - item.rules is not defined or interfaces_use_nmconnection
     - ansible_facts.os_family == 'RedHat'
   register: bridge_rule_del_result
   notify:
@@ -77,8 +80,9 @@
 - name: Create the network configuration file for port on the bridge devices
   become: true
   template:
-    src: 'bridge_port_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path }}/ifcfg-{{ item.1 }}'
+    src: "bridge_port_{{ interfaces_use_nmconnection | ternary('nmconnection', ansible_facts.os_family) }}.j2"
+    dest: "{{ interfaces_net_path }}/{{ interfaces_use_nmconnection | ternary(item.1 ~ '.nmconnection', 'ifcfg-' ~ item.1) }}"
+    mode: "{{ interfaces_use_nmconnection | ternary('0600', omit) }}"
   with_subelements:
     - "{{ interfaces_bridge_interfaces }}"
     - ports

--- a/tasks/bridge_configuration.yml
+++ b/tasks/bridge_configuration.yml
@@ -16,7 +16,7 @@
   become: true
   template:
     src: 'bridge_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/ifcfg-{{ item.device }}'
+    dest: '{{ interfaces_net_path }}/ifcfg-{{ item.device }}'
   with_items: '{{ interfaces_bridge_interfaces }}'
   register: bridge_result
   notify:
@@ -26,7 +26,7 @@
   become: true
   template:
     src: 'route_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
+    dest: '{{ interfaces_net_path }}/route-{{ item.device }}'
   with_items: '{{ interfaces_bridge_interfaces }}'
   when:
     - item.route is defined
@@ -38,7 +38,7 @@
 - name: RedHat | Remove configuration files for rhel route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
+    path: '{{ interfaces_net_path }}/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bridge_interfaces }}'
   when:
@@ -52,7 +52,7 @@
   become: true
   template:
     src: 'rule_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
+    dest: '{{ interfaces_net_path }}/rule-{{ item.device }}'
   with_items: '{{ interfaces_bridge_interfaces }}'
   when:
     - item.rules is defined
@@ -64,7 +64,7 @@
 - name: RedHat | Remove configuration files for rhel rule configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
+    path: '{{ interfaces_net_path }}/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bridge_interfaces }}'
   when:
@@ -78,7 +78,7 @@
   become: true
   template:
     src: 'bridge_port_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/ifcfg-{{ item.1 }}'
+    dest: '{{ interfaces_net_path }}/ifcfg-{{ item.1 }}'
   with_subelements:
     - "{{ interfaces_bridge_interfaces }}"
     - ports

--- a/tasks/bridge_configuration.yml
+++ b/tasks/bridge_configuration.yml
@@ -28,7 +28,9 @@
     src: 'route_{{ ansible_facts.os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
   with_items: '{{ interfaces_bridge_interfaces }}'
-  when: item.route is defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.route is defined
+    - ansible_facts.os_family == 'RedHat'
   register: bridge_route_add_result
   notify:
     - Bounce network devices
@@ -39,7 +41,9 @@
     path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bridge_interfaces }}'
-  when: item.route is not defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.route is not defined
+    - ansible_facts.os_family == 'RedHat'
   register: bridge_route_del_result
   notify:
     - Bounce network devices
@@ -50,7 +54,9 @@
     src: 'rule_{{ ansible_facts.os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
   with_items: '{{ interfaces_bridge_interfaces }}'
-  when: item.rules is defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.rules is defined
+    - ansible_facts.os_family == 'RedHat'
   register: bridge_rule_add_result
   notify:
     - Bounce network devices
@@ -61,7 +67,9 @@
     path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_bridge_interfaces }}'
-  when: item.rules is not defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.rules is not defined
+    - ansible_facts.os_family == 'RedHat'
   register: bridge_rule_del_result
   notify:
     - Bounce network devices
@@ -76,7 +84,8 @@
     - ports
   # Don't configure bridge ports that are bonds here - they will have been
   # configured by the bond tasks.
-  when: item.1 not in interfaces_bond_interfaces | map(attribute='device') | list
+  when:
+    - item.1 not in interfaces_bond_interfaces | map(attribute='device') | list
   register: bridge_port_result
   notify:
     - Bounce network devices

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Debian | install current/latest network packages versions
   apt:
-    pkg: '{{ interfaces_pkgs["debian"]  }}'
+    pkg: '{{ interfaces_pkgs }}'
     state: '{{ interfaces_pkg_state }}'
     update_cache: yes
     cache_valid_time: 3600
@@ -46,7 +46,7 @@
 - name: Debian | Create the directory for interface cfg files
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}'
+    path: '{{ interfaces_net_path }}'
     state: directory
   tags: configuration
 

--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -28,7 +28,9 @@
     src: 'route_{{ ansible_facts.os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.route is defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.route is defined
+    - ansible_facts.os_family == 'RedHat'
   register: ether_route_add_result
   notify:
     - Bounce network devices
@@ -39,7 +41,10 @@
     src: 'route6_{{ ansible_facts.os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route6-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.ip6 is defined and item.ip6.route is defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.ip6 is defined
+    - item.ip6.route is defined
+    - ansible_facts.os_family == 'RedHat'
   register: ether_route6_add_result
   notify:
     - Bounce network devices
@@ -50,7 +55,9 @@
     path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.route is not defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.route is not defined
+    - ansible_facts.os_family == 'RedHat'
   register: ether_route_del_result
   notify:
     - Bounce network devices
@@ -61,7 +68,9 @@
     path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route6-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.ip6 is not defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.ip6 is not defined
+    - ansible_facts.os_family == 'RedHat'
   register: ether_route6_del_result
   notify:
     - Bounce network devices
@@ -72,7 +81,9 @@
     src: 'rule_{{ ansible_facts.os_family }}.j2'
     dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.rules is defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.rules is defined
+    - ansible_facts.os_family == 'RedHat'
   register: ether_rule_add_result
   notify:
     - Bounce network devices
@@ -83,7 +94,9 @@
     path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
-  when: item.rules is not defined and ansible_facts.os_family == 'RedHat'
+  when:
+    - item.rules is not defined
+    - ansible_facts.os_family == 'RedHat'
   register: ether_rule_del_result
   notify:
     - Bounce network devices

--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -15,8 +15,9 @@
 - name: Create the network configuration file for ethernet devices
   become: true
   template:
-    src: 'ethernet_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path }}/ifcfg-{{ item.device }}'
+    src: "ethernet_{{ interfaces_use_nmconnection | ternary('nmconnection', ansible_facts.os_family) }}.j2"
+    dest: "{{ interfaces_net_path }}/{{ interfaces_use_nmconnection | ternary(item.device ~ '.nmconnection', 'ifcfg-' ~ item.device) }}"
+    mode: "{{ interfaces_use_nmconnection | ternary('0600', omit) }}"
   with_items: '{{ interfaces_ether_interfaces }}'
   register: ether_result
   notify:
@@ -31,6 +32,7 @@
   when:
     - item.route is defined
     - ansible_facts.os_family == 'RedHat'
+    - not interfaces_use_nmconnection
   register: ether_route_add_result
   notify:
     - Bounce network devices
@@ -45,6 +47,7 @@
     - item.ip6 is defined
     - item.ip6.route is defined
     - ansible_facts.os_family == 'RedHat'
+    - not interfaces_use_nmconnection
   register: ether_route6_add_result
   notify:
     - Bounce network devices
@@ -56,7 +59,7 @@
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
   when:
-    - item.route is not defined
+    - item.route is not defined or interfaces_use_nmconnection
     - ansible_facts.os_family == 'RedHat'
   register: ether_route_del_result
   notify:
@@ -69,7 +72,7 @@
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
   when:
-    - item.ip6 is not defined
+    - item.ip6 is not defined or interfaces_use_nmconnection
     - ansible_facts.os_family == 'RedHat'
   register: ether_route6_del_result
   notify:
@@ -84,6 +87,7 @@
   when:
     - item.rules is defined
     - ansible_facts.os_family == 'RedHat'
+    - not interfaces_use_nmconnection
   register: ether_rule_add_result
   notify:
     - Bounce network devices
@@ -95,7 +99,7 @@
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
   when:
-    - item.rules is not defined
+    - item.rules is not defined or interfaces_use_nmconnection
     - ansible_facts.os_family == 'RedHat'
   register: ether_rule_del_result
   notify:

--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -16,7 +16,7 @@
   become: true
   template:
     src: 'ethernet_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/ifcfg-{{ item.device }}'
+    dest: '{{ interfaces_net_path }}/ifcfg-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
   register: ether_result
   notify:
@@ -26,7 +26,7 @@
   become: true
   template:
     src: 'route_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
+    dest: '{{ interfaces_net_path }}/route-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
   when:
     - item.route is defined
@@ -39,7 +39,7 @@
   become: true
   template:
     src: 'route6_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route6-{{ item.device }}'
+    dest: '{{ interfaces_net_path }}/route6-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
   when:
     - item.ip6 is defined
@@ -52,7 +52,7 @@
 - name: RedHat | Remove configuration files for rhel route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route-{{ item.device }}'
+    path: '{{ interfaces_net_path }}/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
   when:
@@ -65,7 +65,7 @@
 - name: RedHat | Remove configuration files for rhel v6 route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/route6-{{ item.device }}'
+    path: '{{ interfaces_net_path }}/route6-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
   when:
@@ -79,7 +79,7 @@
   become: true
   template:
     src: 'rule_{{ ansible_facts.os_family }}.j2'
-    dest: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
+    dest: '{{ interfaces_net_path }}/rule-{{ item.device }}'
   with_items: '{{ interfaces_ether_interfaces }}'
   when:
     - item.rules is defined
@@ -91,7 +91,7 @@
 - name: RedHat | Remove configuration files for rhel rule configuration
   become: true
   file:
-    path: '{{ interfaces_net_path[ansible_facts.os_family|lower] }}/rule-{{ item.device }}'
+    path: '{{ interfaces_net_path }}/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
   when:

--- a/tasks/ethernet_configuration.yml
+++ b/tasks/ethernet_configuration.yml
@@ -55,7 +55,7 @@
 - name: RedHat | Remove configuration files for rhel route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path }}/route-{{ item.device }}'
+    path: '/etc/sysconfig/network-scripts/route-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
   when:
@@ -68,7 +68,7 @@
 - name: RedHat | Remove configuration files for rhel v6 route configuration
   become: true
   file:
-    path: '{{ interfaces_net_path }}/route6-{{ item.device }}'
+    path: '/etc/sysconfig/network-scripts/route6-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
   when:
@@ -95,7 +95,7 @@
 - name: RedHat | Remove configuration files for rhel rule configuration
   become: true
   file:
-    path: '{{ interfaces_net_path }}/rule-{{ item.device }}'
+    path: '/etc/sysconfig/network-scripts/rule-{{ item.device }}'
     state: absent
   with_items: '{{ interfaces_ether_interfaces }}'
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Gather variables for each operating system
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_version'] | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+        - "{{ ansible_facts['distribution'] | lower }}.yml"
+        - "{{ ansible_facts['os_family'] | lower }}.yml"
+      paths:
+        - "{{ role_path }}/vars"
 
 - include_tasks: "{{ ansible_facts.os_family | lower }}.yml"
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -7,6 +7,18 @@
   tags: package
   when: not interfaces_use_networkmanager
 
+- name: RedHat | install NM-dispatcher-routing-rules
+  become: true
+  package:
+    name: NetworkManager-dispatcher-routing-rules
+    state: '{{ interfaces_pkg_state }}'
+  tags: package
+  when:
+    - interfaces_use_networkmanager
+    - not interfaces_use_nmconnection
+    - interfaces_route_tables | length > 0
+  notify: Restart NetworkManager
+
 # CentOS 8 cloud images ship with ifcfg files for ens3 and eth0. ifcfg-ens3
 # seems to be a relic from the image build process, and causes the network
 # service to fail. ifcfg-eth0 is useful for most virtual machines, but if a

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -27,3 +27,20 @@
     - item not in interfaces_bond_interfaces | map(attribute='device') | list
     - item not in interfaces_bond_interfaces | map(attribute='bond_slaves') | flatten | list
   with_items: "{{ interfaces_workaround_centos_remove }}"
+
+# When using NetworkManager with system-connections store, existing ifcfg files
+# need to be removed, otherwise they shadow our nmconnection files. We do this
+# only for interfaces that we manage in this role.
+- name: RedHat | remove network-scripts/ifcfg configuration for NM/system-connections
+  become: true
+  file:
+    path: "/etc/sysconfig/network-scripts/ifcfg-{{ item }}"
+    state: absent
+  when:
+    - interfaces_use_nmconnection
+  with_items:
+    - "{{ interfaces_ether_interfaces | map(attribute='device') | list }}"
+    - "{{ interfaces_bridge_interfaces | map(attribute='device') | list }}"
+    - "{{ interfaces_bridge_interfaces | map(attribute='ports') | flatten | list }}"
+    - "{{ interfaces_bond_interfaces | map(attribute='device') | list }}"
+    - "{{ interfaces_bond_interfaces | map(attribute='bond_slaves') | flatten | list }}"

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -2,7 +2,7 @@
 - name: RedHat | install current/latest network packages versions
   become: true
   package:
-    name: '{{  interfaces_pkgs["redhat"][ansible_facts.distribution_major_version] }}'
+    name: '{{  interfaces_pkgs }}'
     state: '{{ interfaces_pkg_state }}'
   tags: package
   when: not interfaces_use_networkmanager

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -5,6 +5,7 @@
     name: '{{  interfaces_pkgs["redhat"][ansible_facts.distribution_major_version] }}'
     state: '{{ interfaces_pkg_state }}'
   tags: package
+  when: not interfaces_use_networkmanager
 
 # CentOS 8 cloud images ship with ifcfg files for ens3 and eth0. ifcfg-ens3
 # seems to be a relic from the image build process, and causes the network

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -10,4 +10,6 @@
     name: network
     enabled: true
     state: started
-  when: ansible_facts.os_family == 'RedHat'
+  when:
+    - ansible_facts.os_family == 'RedHat'
+    - not interfaces_use_networkmanager

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -64,19 +64,22 @@ bond-slaves {{ item.bond_slaves|join(' ') }}
 
 {% for i in item.route | default([]) %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
-{% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
-{% set route = i.network ~ '/' ~ prefix %}
-{% if 'gateway' in i %}
-{% set route = route ~ ' via ' ~ i.gateway %}
-{% else %}
-{% set route = route ~ ' dev ' ~ item.device %}
-{% endif %}
-{% if 'table' in i %}
-{% set route = route ~ ' table ' ~ i.table %}
-{% endif %}
-{% if 'options' in i %}
-{% set route = route ~ ' ' ~ i.options | join(' ') %}
-{% endif %}
+{%   set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{%   set route = i.network ~ '/' ~ prefix %}
+{%   if 'gateway' in i %}
+{%     set route = route ~ ' via ' ~ i.gateway %}
+{%   else %}
+{%     set route = route ~ ' dev ' ~ item.device %}
+{%   endif %}
+{%   if 'table' in i %}
+{%     set route = route ~ ' table ' ~ i.table %}
+{%   endif %}
+{%   for option in i.options | default([]) %}
+{%     if option is mapping %}
+{%       set option = (option | dict2items | first).key %}
+{%     endif %}
+{%     set route = route ~ ' ' ~ option %}
+{%   endfor %}
 up ip route add {{ route }}
 down ip route del {{ route }}
 {% endfor %}

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -62,8 +62,7 @@ bond-slaves none
 bond-slaves {{ item.bond_slaves|join(' ') }}
 {% endif %}
 
-{%- if item.route is defined %}
-{% for i in item.route %}
+{% for i in item.route | default([]) %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
 {% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
 {% set route = i.network ~ '/' ~ prefix %}
@@ -81,7 +80,6 @@ bond-slaves {{ item.bond_slaves|join(' ') }}
 up ip route add {{ route }}
 down ip route del {{ route }}
 {% endfor %}
-{% endif %}
 
 {%- if item.rules is defined %}
 {% for rule in item.rules %}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -30,7 +30,7 @@ ONBOOT={{ item.onboot | bool | ternary('yes', 'no') }}
 {% endif %}
 BONDING_OPTS="{% if item.bond_mode is defined %}mode={{ item.bond_mode }} {% endif %}{% if item.bond_ad_select is defined %}ad_select={{ item.bond_ad_select }} {% endif %}{% if item.bond_updelay is defined %}updelay={{ item.bond_updelay }} {% endif %}{% if item.bond_downdelay is defined %}downdelay={{ item.bond_downdelay }} {% endif %}{% if item.bond_xmit_hash_policy is defined %}xmit_hash_policy={{ item.bond_xmit_hash_policy }} {% endif %}{% if item.bond_lacp_rate is defined %}lacp_rate={{ item.bond_lacp_rate }} {% endif %}{% if item.bond_primary is defined %}primary={{ item.bond_primary }} {% endif %}miimon={{ item.bond_miimon|default(100) }}"
 {% if ansible_facts.distribution_major_version | int >= 7 %}
-NM_CONTROLLED=no
+NM_CONTROLLED={{ interfaces_use_networkmanager | ternary('yes', 'no') }}
 {% endif %}
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -1,5 +1,6 @@
 # {{ ansible_managed }}
 
+NAME={{ item.device }}
 DEVICE={{ item.device }}
 TYPE=Bond
 {% if item.hwaddr is defined %}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -56,10 +56,26 @@ gateway={{ item.gateway }}
 method=disabled
 {% endif %}
 {% for route in item.route | default([]) %}
+{%   set route_options = [] %}
+{%   for option in route.options | default([]) %}
+{%     if option is mapping %}
+{#       We're gonna assume it's a mapping of one key with value, and     #}
+{#       since dict2items returns a array, we're selecting the first item #}
+{%       set option = option | dict2items | first %}
+{%       set _ = route_options.append(option.key ~ '=' ~ option.value) %}
+{%     elif option in ['onlink', 'lock-window', 'lock-cwdn', 'lock-mtu'] %}
+{%       set _ = route_options.append(option ~ '=true') %}
+{%     else %}
+{%       set _ = route_options.append(option) %}
+{%     endif %}
+{%   endfor %}
 {%   if 'gateway' in route %}
 route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
 {%   endif %}
-{#   TODO: dev, table, options #}
+{#   TODO: dev, table #}
+{%   if route_options | length %}
+route{{ loop.index }}_options={{ route_options | join(',') }}
+{%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
 dns={{ item.dnsnameservers | join(',') }}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -69,12 +69,31 @@ method=disabled
 {%       set _ = route_options.append(option) %}
 {%     endif %}
 {%   endfor %}
+{#   TODO: dev #}
 {%   if 'gateway' in route %}
 route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
 {%   endif %}
-{#   TODO: dev, table #}
+{%   if 'table' in route %}
+{#     networkmanager wants a table id, so we need to find it in interfaces_route_tables #}
+{%     set table_id = (interfaces_route_tables | selectattr('name', 'equalto', route.table) | first).id %}
+{%     set _ = route_options.append('table=' ~ table_id) %}
+{%   endif %}
 {%   if route_options | length %}
 route{{ loop.index }}_options={{ route_options | join(',') }}
+{%   endif %}
+{% endfor %}
+{% for rule in item.rules | default([]) %}
+{%   if rule is mapping %}
+{#     networkmanager wants a table id, so we need to find it in interfaces_route_tables #}
+{%     set table_id = (interfaces_route_tables | selectattr('name', 'equalto', rule.table) | first).id %}
+{%     if rule.to is defined %}
+routing-rule{{ loop.index }}=priority {{ rule.priority | default(32765 - loop.index0) }} to {{ rule.to }} table {{ table_id }}
+{%     endif %}
+{%     if rule.from is defined %}
+routing-rule{{ loop.index }}=priority {{ rule.priority | default(32765 - loop.index0) }} from {{ rule.from }} table {{ table_id }}
+{%     endif %}
+{%   else %}
+routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -1,0 +1,89 @@
+# {{ ansible_managed }}
+
+[connection]
+id={{ item.device }}
+type=bond
+interface-name={{ item.device }}
+{% if item.zone is defined %}
+zone={{ item.zone }}
+{% endif %}
+
+{% for bridge in interfaces_bridge_interfaces %}
+{%   if item.device in bridge.ports %}
+master={{ bridge.device }}
+slave-type=bridge
+{%   endif %}
+{% endfor %}
+
+{% if item.mtu is defined %}
+[ethernet]
+mtu={{ item.mtu }}
+{% endif %}
+
+[bond]
+{% if item.bond_ad_select is defined %}
+ad_select={{ item.bond_ad_select }}
+{% endif %}
+{% if item.bond_downdelay is defined %}
+downdelay={{ item.bond_downdelay }}
+{% endif %}
+{% if item.bond_lacp_rate is defined %}
+lacp_rate={{ item.bond_lacp_rate }}
+{% endif %}
+miimon={{ item.bond_miimon | default(100) }}
+{% if item.bond_mode is defined %}
+mode={{ item.bond_mode }}
+{% endif %}
+{% if item.bond_updelay is defined %}
+updelay={{ item.bond_updelay }}
+{% endif %}
+{% if item.bond_xmit_hash_policy is defined %}
+xmit_hash_policy={{ item.bond_xmit_hash_policy }}
+{% endif %}
+
+[ipv4]
+{% if item.bootproto == 'dhcp' %}
+method=auto
+{% elif item.bootproto == 'static' and item.address is defined and item.address | length %}
+method=manual
+{%   if item.netmask is defined %}
+address1={{ (item.address ~'/'~ item.netmask) | ipaddr('host/prefix') }}
+{%   endif %}
+{%   if item.gateway is defined and item.gateway | length %}
+gateway={{ item.gateway }}
+{%   endif %}
+{% else %}
+method=disabled
+{% endif %}
+{% if item.route is defined %}
+{%   for i in item.route %}
+{%     if 'gateway' in i %}
+route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
+{%     endif %}
+{#     TODO: dev, table, options #}
+{%   endfor %}
+{% endif %}
+{% if item.dnsnameservers is defined %}
+dns={{ item.dnsnameservers | join(',') }}
+{% endif %}
+
+[ipv6]
+{% if item.ip6 is defined %}
+method={{ (item.bootproto == 'static') | ternary('manual', 'auto') }}
+{%   if item.ip6.address is defined and item.ip6.netmask is defined %}
+address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ipaddr('host/prefix') }}
+{%   endif %}
+{%   if item.ip6.gateway is defined %}
+gateway={{ item.ip6.gateway }}
+{%   endif %}
+{%   if item.ip6.route is defined %}
+{%     for i in item.ip6.route %}
+{%       if 'gateway' in i %}
+route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
+{%       endif %}
+{#       TODO: dev, table, options #}
+{%     endfor %}
+{%   endif %}
+{% else %}
+method=disabled
+{% endif %}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -55,14 +55,12 @@ gateway={{ item.gateway }}
 {% else %}
 method=disabled
 {% endif %}
-{% if item.route is defined %}
-{%   for i in item.route %}
-{%     if 'gateway' in i %}
-route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
-{%     endif %}
-{#     TODO: dev, table, options #}
-{%   endfor %}
-{% endif %}
+{% for route in item.route | default([]) %}
+{%   if 'gateway' in route %}
+route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+{%   endif %}
+{#   TODO: dev, table, options #}
+{% endfor %}
 {% if item.dnsnameservers is defined %}
 dns={{ item.dnsnameservers | join(',') }}
 {% endif %}
@@ -76,14 +74,12 @@ address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ipaddr('host/prefix') }}
 {%   if item.ip6.gateway is defined %}
 gateway={{ item.ip6.gateway }}
 {%   endif %}
-{%   if item.ip6.route is defined %}
-{%     for i in item.ip6.route %}
-{%       if 'gateway' in i %}
-route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
-{%       endif %}
-{#       TODO: dev, table, options #}
-{%     endfor %}
-{%   endif %}
+{%   for route in item.ip6.route | default([]) %}
+{%     if 'gateway' in route %}
+route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+{%     endif %}
+{#     TODO: dev, table, options #}
+{%   endfor %}
 {% else %}
 method=disabled
 {% endif %}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -71,8 +71,11 @@ method=disabled
 {%   endfor %}
 {#   TODO: dev #}
 {%   if 'gateway' in route %}
-route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') ~ ',' ~ route.gateway %}
+{%   else %}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') %}
 {%   endif %}
+route{{ loop.index }}={{ route_string }}
 {%   if 'table' in route %}
 {#     networkmanager wants a table id, so we need to find it in interfaces_route_tables #}
 {%     set table_id = (interfaces_route_tables | selectattr('name', 'equalto', route.table) | first).id %}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -57,10 +57,12 @@ method=disabled
 {% endif %}
 {% for route in item.route | default([]) %}
 {%   set route_options = [] %}
-{%   for option in route.options | default([]) %}
+{#       Ignoring dev option - needed in Network Scripts  #}
+{#       as it is not needed in Network Manager           #}
+{%   for option in route.options | default([]) | reject('match', '^dev ') %}
 {%     if option is mapping %}
 {#       We're gonna assume it's a mapping of one key with value, and     #}
-{#       since dict2items returns a array, we're selecting the first item #}
+{#       since dict2items returns an array, we're selecting the first item #}
 {%       set option = option | dict2items | first %}
 {%       set _ = route_options.append(option.key ~ '=' ~ option.value) %}
 {%     elif option in ['onlink', 'lock-window', 'lock-cwdn', 'lock-mtu'] %}
@@ -69,7 +71,6 @@ method=disabled
 {%       set _ = route_options.append(option) %}
 {%     endif %}
 {%   endfor %}
-{#   TODO: dev #}
 {%   if 'gateway' in route %}
 {%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') ~ ',' ~ route.gateway %}
 {%   else %}

--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -1,5 +1,6 @@
 # {{ ansible_managed }}
 
+NAME={{ item.1 }}
 DEVICE={{ item.1 }}
 BOOTPROTO=none
 MASTER={{ item.0.device }}

--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -17,5 +17,5 @@ VLAN=yes
 {% endif %}
 
 {% if ansible_facts.distribution_major_version | int >= 7 %}
-NM_CONTROLLED=no
+NM_CONTROLLED={{ interfaces_use_networkmanager | ternary('yes', 'no') }}
 {% endif %}

--- a/templates/bond_slave_nmconnection.j2
+++ b/templates/bond_slave_nmconnection.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+[connection]
+id={{ item.1 }}
+type=ethernet
+interface-name={{ item.1 }}
+
+master={{ item.0.device }}
+slave-type=bond

--- a/templates/bond_slave_nmconnection.j2
+++ b/templates/bond_slave_nmconnection.j2
@@ -2,7 +2,7 @@
 
 [connection]
 id={{ item.1 }}
-type=ethernet
+type={{ (item.1 is match(dummy_interface_regex)) | ternary('dummy', 'ethernet') }}
 interface-name={{ item.1 }}
 
 master={{ item.0.device }}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -44,8 +44,7 @@ bridge_fd {{ item.fd }}
 bridge-vlan-aware {{ item.vlan_aware }}
 {% endif %}
 
-{%- if item.route is defined %}
-{% for i in item.route %}
+{% for i in item.route | default([]) %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
 {% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
 {% set route = i.network ~ '/' ~ prefix %}
@@ -63,7 +62,6 @@ bridge-vlan-aware {{ item.vlan_aware }}
 up ip route add {{ route }}
 down ip route del {{ route }}
 {% endfor %}
-{% endif %}
 
 {%- if item.rules is defined %}
 {% for rule in item.rules %}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -56,9 +56,12 @@ bridge-vlan-aware {{ item.vlan_aware }}
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
 {% endif %}
-{% if 'options' in i %}
-{% set route = route ~ ' ' ~ i.options | join(' ') %}
-{% endif %}
+{% for option in i.options | default([]) %}
+{%   if option is mapping %}
+{%     set option = (option | dict2items | first).key %}
+{%   endif %}
+{%   set route = route ~ ' ' ~ option %}
+{% endfor %}
 up ip route add {{ route }}
 down ip route del {{ route }}
 {% endfor %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -31,7 +31,7 @@ DEFROUTE={{ item.defroute | bool | ternary('yes', 'no') }}
 ONBOOT={{ item.onboot | bool | ternary('yes', 'no') }}
 {% endif %}
 {% if ansible_facts.distribution_major_version | int >= 7 %}
-NM_CONTROLLED=no
+NM_CONTROLLED={{ interfaces_use_networkmanager | ternary('yes', 'no') }}
 {% endif %}
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -1,5 +1,6 @@
 # {{ ansible_managed }}
 
+NAME={{ item.device }}
 DEVICE={{ item.device }}
 TYPE=Bridge
 {% if item.hwaddr is defined %}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -34,10 +34,26 @@ gateway={{ item.gateway }}
 method=disabled
 {% endif %}
 {% for route in item.route | default([]) %}
+{%   set route_options = [] %}
+{%   for option in route.options | default([]) %}
+{%     if option is mapping %}
+{#       We're gonna assume it's a mapping of one key with value, and     #}
+{#       since dict2items returns a array, we're selecting the first item #}
+{%       set option = option | dict2items | first %}
+{%       set _ = route_options.append(option.key ~ '=' ~ option.value) %}
+{%     elif option in ['onlink', 'lock-window', 'lock-cwdn', 'lock-mtu'] %}
+{%       set _ = route_options.append(option ~ '=true') %}
+{%     else %}
+{%       set _ = route_options.append(option) %}
+{%     endif %}
+{%   endfor %}
 {%   if 'gateway' in route %}
 route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
 {%   endif %}
-{#   TODO: dev, table, options #}
+{#   TODO: dev, table #}
+{%   if route_options | length %}
+route{{ loop.index }}_options={{ route_options | join(',') }}
+{%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
 dns={{ item.dnsnameservers | join(',') }}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -1,0 +1,67 @@
+# {{ ansible_managed }}
+
+[connection]
+id={{ item.device }}
+type=bridge
+interface-name={{ item.device }}
+{% if item.zone is defined %}
+zone={{ item.zone }}
+{% endif %}
+
+{% if item.mtu is defined %}
+[ethernet]
+mtu={{ item.mtu }}
+{% endif %}
+
+[bridge]
+interface-name={{ item.device }}
+{% if item.stp is defined %}
+stp={{ item.stp }}
+{% endif %}
+
+[ipv4]
+{% if item.bootproto == 'dhcp' %}
+method=auto
+{% elif item.bootproto == 'static' and item.address is defined and item.address | length %}
+method=manual
+{%   if item.netmask is defined %}
+address1={{ (item.address ~'/'~ item.netmask) | ipaddr('host/prefix') }}
+{%   endif %}
+{%   if item.gateway is defined and item.gateway | length %}
+gateway={{ item.gateway }}
+{%   endif %}
+{% else %}
+method=disabled
+{% endif %}
+{% if item.route is defined %}
+{%   for i in item.route %}
+{%     if 'gateway' in i %}
+route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
+{%     endif %}
+{#     TODO: dev, table, options #}
+{%   endfor %}
+{% endif %}
+{% if item.dnsnameservers is defined %}
+dns={{ item.dnsnameservers | join(',') }}
+{% endif %}
+
+[ipv6]
+{% if item.ip6 is defined %}
+method={{ (item.bootproto == 'static') | ternary('manual', 'auto') }}
+{%   if item.ip6.address is defined and item.ip6.netmask is defined %}
+address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ipaddr('host/prefix') }}
+{%   endif %}
+{%   if item.ip6.gateway is defined %}
+gateway={{ item.ip6.gateway }}
+{%   endif %}
+{%   if item.ip6.route is defined %}
+{%     for i in item.ip6.route %}
+{%       if 'gateway' in i %}
+route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
+{%       endif %}
+{#       TODO: dev, table, options #}
+{%     endfor %}
+{%   endif %}
+{% else %}
+method=disabled
+{% endif %}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -47,12 +47,31 @@ method=disabled
 {%       set _ = route_options.append(option) %}
 {%     endif %}
 {%   endfor %}
+{#   TODO: dev #}
 {%   if 'gateway' in route %}
 route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
 {%   endif %}
-{#   TODO: dev, table #}
+{%   if 'table' in route %}
+{#     networkmanager wants a table id, so we need to find it in interfaces_route_tables #}
+{%     set table_id = (interfaces_route_tables | selectattr('name', 'equalto', route.table) | first).id %}
+{%     set _ = route_options.append('table=' ~ table_id) %}
+{%   endif %}
 {%   if route_options | length %}
 route{{ loop.index }}_options={{ route_options | join(',') }}
+{%   endif %}
+{% endfor %}
+{% for rule in item.rules | default([]) %}
+{%   if rule is mapping %}
+{#     networkmanager wants a table id, so we need to find it in interfaces_route_tables #}
+{%     set table_id = (interfaces_route_tables | selectattr('name', 'equalto', rule.table) | first).id %}
+{%     if rule.to is defined %}
+routing-rule{{ loop.index }}=priority {{ rule.priority | default(32765 - loop.index0) }} to {{ rule.to }} table {{ table_id }}
+{%     endif %}
+{%     if rule.from is defined %}
+routing-rule{{ loop.index }}=priority {{ rule.priority | default(32765 - loop.index0) }} from {{ rule.from }} table {{ table_id }}
+{%     endif %}
+{%   else %}
+routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -33,14 +33,12 @@ gateway={{ item.gateway }}
 {% else %}
 method=disabled
 {% endif %}
-{% if item.route is defined %}
-{%   for i in item.route %}
-{%     if 'gateway' in i %}
-route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
-{%     endif %}
-{#     TODO: dev, table, options #}
-{%   endfor %}
-{% endif %}
+{% for route in item.route | default([]) %}
+{%   if 'gateway' in route %}
+route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+{%   endif %}
+{#   TODO: dev, table, options #}
+{% endfor %}
 {% if item.dnsnameservers is defined %}
 dns={{ item.dnsnameservers | join(',') }}
 {% endif %}
@@ -54,14 +52,12 @@ address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ipaddr('host/prefix') }}
 {%   if item.ip6.gateway is defined %}
 gateway={{ item.ip6.gateway }}
 {%   endif %}
-{%   if item.ip6.route is defined %}
-{%     for i in item.ip6.route %}
-{%       if 'gateway' in i %}
-route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
-{%       endif %}
-{#       TODO: dev, table, options #}
-{%     endfor %}
-{%   endif %}
+{%   for route in item.ip6.route | default([]) %}
+{%     if 'gateway' in route %}
+route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+{%     endif %}
+{#     TODO: dev, table, options #}
+{%   endfor %}
 {% else %}
 method=disabled
 {% endif %}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -35,10 +35,12 @@ method=disabled
 {% endif %}
 {% for route in item.route | default([]) %}
 {%   set route_options = [] %}
-{%   for option in route.options | default([]) %}
+{#       Ignoring dev option - needed in Network Scripts  #}
+{#       as it is not needed in Network Manager           #}
+{%   for option in route.options | default([]) | reject('match', '^dev ') %}
 {%     if option is mapping %}
 {#       We're gonna assume it's a mapping of one key with value, and     #}
-{#       since dict2items returns a array, we're selecting the first item #}
+{#       since dict2items returns an array, we're selecting the first item #}
 {%       set option = option | dict2items | first %}
 {%       set _ = route_options.append(option.key ~ '=' ~ option.value) %}
 {%     elif option in ['onlink', 'lock-window', 'lock-cwdn', 'lock-mtu'] %}
@@ -47,7 +49,6 @@ method=disabled
 {%       set _ = route_options.append(option) %}
 {%     endif %}
 {%   endfor %}
-{#   TODO: dev #}
 {%   if 'gateway' in route %}
 {%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') ~ ',' ~ route.gateway %}
 {%   else %}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -49,8 +49,11 @@ method=disabled
 {%   endfor %}
 {#   TODO: dev #}
 {%   if 'gateway' in route %}
-route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') ~ ',' ~ route.gateway %}
+{%   else %}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') %}
 {%   endif %}
+route{{ loop.index }}={{ route_string }}
 {%   if 'table' in route %}
 {#     networkmanager wants a table id, so we need to find it in interfaces_route_tables #}
 {%     set table_id = (interfaces_route_tables | selectattr('name', 'equalto', route.table) | first).id %}

--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -1,5 +1,6 @@
 # {{ ansible_managed }}
 
+NAME={{ item.1 }}
 DEVICE={{ item.1 }}
 TYPE={{ (item.1 is match(vlan_interface_regex)) | ternary('Vlan', 'Ethernet') }}
 BOOTPROTO=none

--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 DEVICE={{ item.1 }}
-TYPE=Ethernet
+TYPE={{ (item.1 is match(vlan_interface_regex)) | ternary('Vlan', 'Ethernet') }}
 BOOTPROTO=none
 BRIDGE={{ item.0.device }}
 

--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -15,7 +15,7 @@ ONBOOT={{ item.0.onboot }}
 {% endif %}
 
 {% if ansible_facts.distribution_major_version | int >= 7 %}
-NM_CONTROLLED=no
+NM_CONTROLLED={{ interfaces_use_networkmanager | ternary('yes', 'no') }}
 {% endif %}
 
 {% if item.1 is match(vlan_interface_regex) %}

--- a/templates/bridge_port_nmconnection.j2
+++ b/templates/bridge_port_nmconnection.j2
@@ -1,0 +1,21 @@
+# {{ ansible_managed }}
+
+[connection]
+id={{ item.1 }}
+type={{ (item.1 is match(vlan_interface_regex)) | ternary('vlan', 'ethernet') }}
+interface-name={{ item.1 }}
+
+master={{ item.0.device }}
+slave-type=bridge
+
+{% if item.0.mtu is defined %}
+[ethernet]
+mtu={{ item.0.mtu }}
+{% endif %}
+
+{% if item.1 is match(vlan_interface_regex) %}
+[vlan]
+interface-name={{ item.1 }}
+parent={{ item.1 | regex_replace(vlan_interface_regex, '\g<interface>') }}
+id={{ item.1 | regex_replace(vlan_interface_regex, '\g<vlan_id>') }}
+{% endif %}

--- a/templates/bridge_port_nmconnection.j2
+++ b/templates/bridge_port_nmconnection.j2
@@ -2,7 +2,7 @@
 
 [connection]
 id={{ item.1 }}
-type={{ (item.1 is match(vlan_interface_regex)) | ternary('vlan', 'ethernet') }}
+type={{ ('vlan' if item.1 is match(vlan_interface_regex) else 'dummy' if item.1 is match(dummy_interface_regex) else 'ethernet') }}
 interface-name={{ item.1 }}
 
 master={{ item.0.device }}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -86,8 +86,7 @@ gateway {{ item.ip6.gateway }}
 {% endif %}
 {% if item.ip6 is defined %}
 
-{% if item.ip6.route is defined %}
-{% for i in item.ip6.route %}
+{% for i in item.ip6.route | default([]) %}
 {% set route = i.network %}
 {% if 'gateway' in i %}
 {% set route = route ~ ' via ' ~ i.gateway %}
@@ -103,5 +102,4 @@ gateway {{ item.ip6.gateway }}
 up ip -6 route add {{ route }}
 down ip -6 route del {{ route }}
 {% endfor %}
-{% endif %}
 {% endif %}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -53,9 +53,12 @@ wpa-conf {{ item.wpaconf }}
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
 {% endif %}
-{% if 'options' in i %}
-{% set route = route ~ ' ' ~ i.options | join(' ') %}
-{% endif %}
+{% for option in i.options | default([]) %}
+{%   if option is mapping %}
+{%     set option = (option | dict2items | first).key %}
+{%   endif %}
+{%   set route = route ~ ' ' ~ option %}
+{% endfor %}
 up ip route add {{ route }}
 down ip route del {{ route }}
 {% endfor %}
@@ -96,9 +99,12 @@ gateway {{ item.ip6.gateway }}
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
 {% endif %}
-{% if 'options' in i %}
-{% set route = route ~ ' ' ~ i.options | join(' ') %}
-{% endif %}
+{% for option in i.options | default([]) %}
+{%   if option is mapping %}
+{%     set option = (option | dict2items | first).key %}
+{%   endif %}
+{%   set route = route ~ ' ' ~ option %}
+{% endfor %}
 up ip -6 route add {{ route }}
 down ip -6 route del {{ route }}
 {% endfor %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 DEVICE={{ item.device }}
-TYPE=Ethernet
+TYPE={{ (item.device is match(vlan_interface_regex)) | ternary('Vlan', 'Ethernet') }}
 {% if item.hwaddr is defined %}
 HWADDR={{ item.hwaddr }}
 {% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -39,7 +39,7 @@ ETHTOOL_OPTS="{{ item.ethtool_opts }}"
 ONBOOT={{ item.onboot | bool | ternary('yes', 'no') }}
 {% endif %}
 {% if ansible_facts.distribution_major_version | int >= 7 %}
-NM_CONTROLLED=no
+NM_CONTROLLED={{ interfaces_use_networkmanager | ternary('yes', 'no') }}
 {% endif %}
 {% if item.device is match(vlan_interface_regex) %}
 VLAN=yes

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -1,5 +1,6 @@
 # {{ ansible_managed }}
 
+NAME={{ item.device }}
 DEVICE={{ item.device }}
 TYPE={{ (item.device is match(vlan_interface_regex)) | ternary('Vlan', 'Ethernet') }}
 {% if item.hwaddr is defined %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -2,7 +2,7 @@
 
 [connection]
 id={{ item.device }}
-type={{ (item.device is match(vlan_interface_regex)) | ternary('vlan', 'ethernet') }}
+type={{ ('vlan' if item.device is match(vlan_interface_regex) else 'dummy' if item.device is match(dummy_interface_regex) else 'ethernet') }}
 interface-name={{ item.device }}
 {% if item.zone is defined %}
 zone={{ item.zone }}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -1,0 +1,75 @@
+# {{ ansible_managed }}
+
+[connection]
+id={{ item.device }}
+type={{ (item.device is match(vlan_interface_regex)) | ternary('vlan', 'ethernet') }}
+interface-name={{ item.device }}
+{% if item.zone is defined %}
+zone={{ item.zone }}
+{% endif %}
+
+{% for bridge in interfaces_bridge_interfaces %}
+{%   if item.device in bridge.ports %}
+master={{ bridge.device }}
+slave-type=bridge
+{%   endif %}
+{% endfor %}
+
+{% if item.mtu is defined %}
+[ethernet]
+mtu={{ item.mtu }}
+{% endif %}
+
+{% if item.device is match(vlan_interface_regex) %}
+[vlan]
+interface-name={{ item.device }}
+parent={{ item.device | regex_replace(vlan_interface_regex, '\g<interface>') }}
+id={{ item.device | regex_replace(vlan_interface_regex, '\g<vlan_id>') }}
+{% endif %}
+
+[ipv4]
+{% if item.bootproto == 'dhcp' %}
+method=auto
+{% elif item.bootproto == 'static' and item.address is defined and item.address | length %}
+method=manual
+{%   if item.netmask is defined %}
+address1={{ (item.address ~'/'~ item.netmask) | ipaddr('host/prefix') }}
+{%   endif %}
+{%   if item.gateway is defined and item.gateway | length %}
+gateway={{ item.gateway }}
+{%   endif %}
+{% else %}
+method=disabled
+{% endif %}
+{% if item.route is defined %}
+{%   for i in item.route %}
+{%     if 'gateway' in i %}
+route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
+{%     endif %}
+{#     TODO: dev, table, options #}
+{%   endfor %}
+{% endif %}
+{% if item.dnsnameservers is defined %}
+dns={{ item.dnsnameservers | join(',') }}
+{% endif %}
+
+[ipv6]
+{% if item.ip6 is defined %}
+method={{ (item.bootproto == 'static') | ternary('manual', 'auto') }}
+{%   if item.ip6.address is defined and item.ip6.netmask is defined %}
+address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ipaddr('host/prefix') }}
+{%   endif %}
+{%   if item.ip6.gateway is defined %}
+gateway={{ item.ip6.gateway }}
+{%   endif %}
+{%   if item.ip6.route is defined %}
+{%     for i in item.ip6.route %}
+{%       if 'gateway' in i %}
+route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
+{%       endif %}
+{#       TODO: dev, table, options #}
+{%     endfor %}
+{%   endif %}
+{% else %}
+method=disabled
+{% endif %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -41,14 +41,12 @@ gateway={{ item.gateway }}
 {% else %}
 method=disabled
 {% endif %}
-{% if item.route is defined %}
-{%   for i in item.route %}
-{%     if 'gateway' in i %}
-route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
-{%     endif %}
-{#     TODO: dev, table, options #}
-{%   endfor %}
-{% endif %}
+{% for route in item.route | default([]) %}
+{%   if 'gateway' in route %}
+route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+{%   endif %}
+{#   TODO: dev, table, options #}
+{% endfor %}
 {% if item.dnsnameservers is defined %}
 dns={{ item.dnsnameservers | join(',') }}
 {% endif %}
@@ -62,14 +60,12 @@ address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ipaddr('host/prefix') }}
 {%   if item.ip6.gateway is defined %}
 gateway={{ item.ip6.gateway }}
 {%   endif %}
-{%   if item.ip6.route is defined %}
-{%     for i in item.ip6.route %}
-{%       if 'gateway' in i %}
-route{{ loop.index }}={{ (i.network ~'/'~ i.netmask) | ipaddr('network/prefix') }},{{ i.gateway }}
-{%       endif %}
-{#       TODO: dev, table, options #}
-{%     endfor %}
-{%   endif %}
+{%   for route in item.ip6.route | default([]) %}
+{%     if 'gateway' in route %}
+route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+{%     endif %}
+{#     TODO: dev, table, options #}
+{%   endfor %}
 {% else %}
 method=disabled
 {% endif %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -42,10 +42,26 @@ gateway={{ item.gateway }}
 method=disabled
 {% endif %}
 {% for route in item.route | default([]) %}
+{%   set route_options = [] %}
+{%   for option in route.options | default([]) %}
+{%     if option is mapping %}
+{#       We're gonna assume it's a mapping of one key with value, and     #}
+{#       since dict2items returns a array, we're selecting the first item #}
+{%       set option = option | dict2items | first %}
+{%       set _ = route_options.append(option.key ~ '=' ~ option.value) %}
+{%     elif option in ['onlink', 'lock-window', 'lock-cwdn', 'lock-mtu'] %}
+{%       set _ = route_options.append(option ~ '=true') %}
+{%     else %}
+{%       set _ = route_options.append(option) %}
+{%     endif %}
+{%   endfor %}
 {%   if 'gateway' in route %}
 route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
 {%   endif %}
-{#   TODO: dev, table, options #}
+{#   TODO: dev, table #}
+{%   if route_options | length %}
+route{{ loop.index }}_options={{ route_options | join(',') }}
+{%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
 dns={{ item.dnsnameservers | join(',') }}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -57,8 +57,11 @@ method=disabled
 {%   endfor %}
 {#   TODO: dev #}
 {%   if 'gateway' in route %}
-route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') ~ ',' ~ route.gateway %}
+{%   else %}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') %}
 {%   endif %}
+route{{ loop.index }}={{ route_string }}
 {%   if 'table' in route %}
 {#     networkmanager wants a table id, so we need to find it in interfaces_route_tables #}
 {%     set table_id = (interfaces_route_tables | selectattr('name', 'equalto', route.table) | first).id %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -55,12 +55,31 @@ method=disabled
 {%       set _ = route_options.append(option) %}
 {%     endif %}
 {%   endfor %}
+{#   TODO: dev #}
 {%   if 'gateway' in route %}
 route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
 {%   endif %}
-{#   TODO: dev, table #}
+{%   if 'table' in route %}
+{#     networkmanager wants a table id, so we need to find it in interfaces_route_tables #}
+{%     set table_id = (interfaces_route_tables | selectattr('name', 'equalto', route.table) | first).id %}
+{%     set _ = route_options.append('table=' ~ table_id) %}
+{%   endif %}
 {%   if route_options | length %}
 route{{ loop.index }}_options={{ route_options | join(',') }}
+{%   endif %}
+{% endfor %}
+{% for rule in item.rules | default([]) %}
+{%   if rule is mapping %}
+{#     networkmanager wants a table id, so we need to find it in interfaces_route_tables #}
+{%     set table_id = (interfaces_route_tables | selectattr('name', 'equalto', rule.table) | first).id %}
+{%     if rule.to is defined %}
+routing-rule{{ loop.index }}=priority {{ rule.priority | default(32765 - loop.index0) }} to {{ rule.to }} table {{ table_id }}
+{%     endif %}
+{%     if rule.from is defined %}
+routing-rule{{ loop.index }}=priority {{ rule.priority | default(32765 - loop.index0) }} from {{ rule.from }} table {{ table_id }}
+{%     endif %}
+{%   else %}
+routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -43,10 +43,12 @@ method=disabled
 {% endif %}
 {% for route in item.route | default([]) %}
 {%   set route_options = [] %}
-{%   for option in route.options | default([]) %}
+{#       Ignoring dev option - needed in Network Scripts  #}
+{#       as it is not needed in Network Manager           #}
+{%   for option in route.options | default([]) | reject('match', '^dev ') %}
 {%     if option is mapping %}
 {#       We're gonna assume it's a mapping of one key with value, and     #}
-{#       since dict2items returns a array, we're selecting the first item #}
+{#       since dict2items returns an array, we're selecting the first item #}
 {%       set option = option | dict2items | first %}
 {%       set _ = route_options.append(option.key ~ '=' ~ option.value) %}
 {%     elif option in ['onlink', 'lock-window', 'lock-cwdn', 'lock-mtu'] %}
@@ -55,7 +57,6 @@ method=disabled
 {%       set _ = route_options.append(option) %}
 {%     endif %}
 {%   endfor %}
-{#   TODO: dev #}
 {%   if 'gateway' in route %}
 {%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') ~ ',' ~ route.gateway %}
 {%   else %}

--- a/templates/route6_RedHat.j2
+++ b/templates/route6_RedHat.j2
@@ -1,8 +1,7 @@
 # {{ ansible_managed }}
 
 {% if item.ip6 is defined %}
-{% if item.ip6.route is defined %}
-{% for i in item.ip6.route %}
+{% for i in item.ip6.route | default([]) %}
 {% set route = i.network %}
 {% if 'gateway' in i %}
 {% set route = route ~ ' via ' ~ i.gateway %}
@@ -17,5 +16,4 @@
 {% endif %}
 {{ route }}
 {% endfor %}
-{% endif %}
 {% endif %}

--- a/templates/route6_RedHat.j2
+++ b/templates/route6_RedHat.j2
@@ -11,9 +11,12 @@
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
 {% endif %}
-{% if 'options' in i %}
-{% set route = route ~ ' ' ~ i.options | join(' ') %}
-{% endif %}
+{% for option in i.options | default([]) %}
+{%   if option is mapping %}
+{%     set option = (option | dict2items | first).key %}
+{%   endif %}
+{%   set route = route ~ ' ' ~ option %}
+{% endfor %}
 {{ route }}
 {% endfor %}
 {% endif %}

--- a/templates/route_RedHat.j2
+++ b/templates/route_RedHat.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-{% for i in item.route %}
+{% for i in item.route | default([]) %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
 {% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
 {% set route = i.network ~ '/' ~ prefix %}

--- a/templates/route_RedHat.j2
+++ b/templates/route_RedHat.j2
@@ -12,8 +12,11 @@
 {% if 'table' in i %}
 {% set route = route ~ ' table ' ~ i.table %}
 {% endif %}
-{% if 'options' in i %}
-{% set route = route ~ ' ' ~ i.options | join(' ') %}
-{% endif %}
+{% for option in i.options | default([]) %}
+{%   if option is mapping %}
+{%     set option = (option | dict2items | first).key %}
+{%   endif %}
+{%   set route = route ~ ' ' ~ option %}
+{% endfor %}
 {{ route }}
 {% endfor %}

--- a/templates/rule_RedHat.j2
+++ b/templates/rule_RedHat.j2
@@ -1,5 +1,14 @@
 # {{ ansible_managed }}
 
 {% for rule in item.rules %}
+{%   if rule is mapping %}
+{%     if rule.to is defined %}
+to {{ rule.to }} table {{ rule.table }}
+{%     endif %}
+{%     if rule.from is defined %}
+from {{ rule.from }} table {{ rule.table }}
+{%     endif %}
+{%   else %}
 {{ rule }}
+{%   endif %}
 {% endfor %}

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,10 @@
+---
+interfaces_pkgs:
+  - bridge-utils
+  - ifenslave
+  - ifupdown
+  - iproute2
+  - python{% if ansible_facts.python.version.major >= 3 %}3{% endif %}-selinux
+  - resolvconf
+
+interfaces_net_path: /etc/network/interfaces.d

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,3 +6,6 @@ vlan_interface_regex: '(?P<interface>.*)\.(?P<vlan_id>\d{1,4})'
 # Regular expression matching the '.<VLAN ID>' suffix of a VLAN interface of
 # the form '<interface>.<VLAN ID>'.
 vlan_interface_suffix_regex: '\.\d{1,4}'
+
+# Regular expression matching a dummy interface base on name
+dummy_interface_regex: 'dummy*'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 # Regular expression matching a VLAN interface of the form
 # '<interface>.<VLAN ID>'.
-vlan_interface_regex: '.*\.\d{1,4}'
+vlan_interface_regex: '(?P<interface>.*)\.(?P<vlan_id>\d{1,4})'
 
 # Regular expression matching the '.<VLAN ID>' suffix of a VLAN interface of
 # the form '<interface>.<VLAN ID>'.

--- a/vars/redhat-7.yml
+++ b/vars/redhat-7.yml
@@ -1,0 +1,8 @@
+---
+interfaces_pkgs:
+  - bridge-utils
+  - iproute
+  - iputils
+  - libselinux-python
+
+interfaces_net_path: /etc/sysconfig/network-scripts

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -5,4 +5,4 @@ interfaces_pkgs:
   - iputils
   - network-scripts
 
-interfaces_net_path: /etc/sysconfig/network-scripts
+interfaces_net_path: "{{ interfaces_use_nmconnection | ternary('/etc/NetworkManager/system-connections', '/etc/sysconfig/network-scripts') }}"

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -1,0 +1,8 @@
+---
+interfaces_pkgs:
+  - dhcp-client
+  - iproute
+  - iputils
+  - network-scripts
+
+interfaces_net_path: /etc/sysconfig/network-scripts

--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -1,0 +1,4 @@
+---
+interfaces_pkgs: []
+
+interfaces_net_path: /etc/NetworkManager/system-connections


### PR DESCRIPTION
network-scripts is deprecated (and removed from el9 releases if I'm not mistaken). In el8 networkmanager does a pretty good job of reading network-scripts, so might aswell try using it.

For el9 support we'll also need to convert the network-scripts files to nmconnection files.