### PR TITLE
Typo in bond-xmit-hash-policy option

### DIFF
--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -48,7 +48,7 @@ bond-downdelay {{ item.bond_downdelay }}
 bond-updelay {{ item.bond_updelay }}
 {% endif %}
 {% if item.bond_xmit_hash_policy is defined %}
-bond-xmit_hash_policy {{ item.bond_xmit_hash_policy }}
+bond-xmit-hash-policy {{ item.bond_xmit_hash_policy }}
 {% endif %}
 {% if item.bond_slaves is defined and item.bond_mode | default == 'active-backup' %}
 bond-slaves none


### PR DESCRIPTION
Ansible variable is called bond_xmit_hash_policy but the linux parameter is `bond-xmit-hash-policy`.