### PR TITLE
Allow setting bridge/interface as manual (Debian)

### DIFF
--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -3,6 +3,9 @@
 {% endif %}
 
 auto {{ item.device }}
+{% if item.bootproto == 'manual' %}
+iface {{ item.device }} inet manual
+{% endif %}
 {% if item.bootproto == 'dhcp' %}
 iface {{ item.device }} inet dhcp
 {% endif %}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -3,6 +3,9 @@
 {% endif %}
 
 {{ item.allowclass | default('auto') }} {{ item.device }}
+{% if item.bootproto == 'manual' %}
+iface {{ item.device }} inet manual
+{% endif %}
 {% if item.bootproto == 'dhcp' %}
 iface {{ item.device }} inet dhcp
 {% endif %}


### PR DESCRIPTION
Hello,

I'd be glad if you could include these two small changes allowing to set interfaces and bridges as manual. We currently use it in one of our configurations.

Regards