### PR TITLE
Allow routes to accept routes as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,8 @@ bouncing network interfaces before they are active. This can be done by setting
 interfaces_route_tables:
     - name: frontend
       id: 200
+    - name: marktable
+      id: 100
 interfaces_ether_interfaces:
     - device: eth1
       bootproto: static
@@ -467,16 +469,11 @@ interfaces_ether_interfaces:
           network: 0.0.0.0
           netmask: 0.0.0.0
           gateway: 10.10.10.254
-        - "local 0.0.0.0/0 dev lo table 100"
+        - "local 0.0.0.0/0 dev lo table marktable"
       rules:
         - from: 10.10.10.1
           table: frontend
-        - "fwmark 1 lookup 100"
-```
-
-### host_vars/proxy2
-
-```yaml
+        - "fwmark 1 lookup marktable"
 ```
 
 Example Playbook

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ configures an IP route on the interface for the `myroutetable` routing table.
 ```
 
 6) Configure a hot-pluggable Wifi interface `wlan0` with a static IP and a
-`wpa_supplicant` configuration. Also configure eth0 with a dhcp IP. 
+`wpa_supplicant` configuration. Also configure eth0 with a dhcp IP.
 
 ```yaml
 - hosts: myhost
@@ -383,7 +383,7 @@ is not supported at this time.
 
 14) Configure firewalld zones (RedHat-family only)
 
-  Adding interface to firewalld zone is possible using the `zone` attribute. 
+  Adding interface to firewalld zone is possible using the `zone` attribute.
   This is only supported on distributions of the RedHat family.
 
   ```yaml
@@ -443,6 +443,40 @@ bouncing network interfaces before they are active. This can be done by setting
           bootproto: dhcp
           hwaddr: 00:11:22:33:44:66
           ports: [eth1, eth2]
+```
+
+18) Routes and rules can be a mix of strings and hashes (a.k.a. dict, mapping, associative array, etc.) allowing
+    the role to handle rules and routes outside the expected formats.
+
+    The example below configures an interface, to act as a second interface so that any traffic that hits it is returned via the same interface. In addition internal traffic is marked so it can be picked up by some other service (like HAproxy).
+
+### host_vars/proxy1
+```yaml
+interfaces_route_tables:
+    - name: frontend
+      id: 200
+interfaces_ether_interfaces:
+    - device: eth1
+      bootproto: static
+      address: 10.10.10.1
+      netmask: 255.255.255.0
+      defroute: false
+      route:
+        - table: frontend
+          device: eth1
+          network: 0.0.0.0
+          netmask: 0.0.0.0
+          gateway: 10.10.10.254
+        - "local 0.0.0.0/0 dev lo table 100"
+      rules:
+        - from: 10.10.10.1
+          table: frontend
+        - "fwmark 1 lookup 100"
+```
+
+### host_vars/proxy2
+
+```yaml
 ```
 
 Example Playbook

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -62,29 +62,35 @@ bond-slaves none
 bond-slaves {{ item.bond_slaves|join(' ') }}
 {% endif %}
 
-{% for i in item.route | default([]) %}
+{% if item.route is defined %}
+{%   for i in item.route %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
-{%   set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
-{%   set route = i.network ~ '/' ~ prefix %}
-{%   if 'gateway' in i %}
-{%     set route = route ~ ' via ' ~ i.gateway %}
-{%   else %}
-{%     set route = route ~ ' dev ' ~ item.device %}
-{%   endif %}
-{%   if 'table' in i %}
-{%     set route = route ~ ' table ' ~ i.table %}
-{%   endif %}
-{%   for option in i.options | default([]) %}
-{%     if option is mapping %}
-{%       set option = (option | dict2items | first).key %}
+{%     if i is mapping %} {# If route is not a mapping, then assume it's a complete rule #}
+{%       set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{%       set route = i.network ~ '/' ~ prefix %}
+{%       if 'gateway' in i %}
+{%         set route = route ~ ' via ' ~ i.gateway %}
+{%       else %}
+{%         set route = route ~ ' dev ' ~ item.device %}
+{%       endif %}
+{%       if 'table' in i %}
+{%         set route = route ~ ' table ' ~ i.table %}
+{%       endif %}
+{%       for option in i.options | default([]) %}
+{%         if option is mapping %}
+{%           set option = (option | dict2items | first).key %}
+{%         endif %}
+{%         set route = route ~ ' ' ~ option %}
+{%       endfor %}
+{%     else %}
+{%       set route = i %}
 {%     endif %}
-{%     set route = route ~ ' ' ~ option %}
-{%   endfor %}
 up ip route add {{ route }}
 down ip route del {{ route }}
-{% endfor %}
+{%   endfor %}
 
-{%- if item.rules is defined %}
+{% endif %}
+{% if item.rules is defined %}
 {% for rule in item.rules %}
 {%   if rule is mapping %}
 {%     if rule.to is defined %}

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -86,7 +86,20 @@ down ip route del {{ route }}
 
 {%- if item.rules is defined %}
 {% for rule in item.rules %}
-up ip rule add {{ rule }}
-down ip rule del {{ rule }}
+{%   if rule is mapping %}
+{%     if rule.to is defined %}
+{%       set rule_str = 'to ' ~ rule.to %}
+{%     endif %}
+{%     if rule.from is defined %}
+{%       set rule_str = 'from ' ~ rule.from %}
+{%     endif %}
+{%     if rule.table is defined %}
+{%       set rule_str = rule_str ~ ' table' ~ rule.table %}
+{%     endif %}
+{%   else %}
+{%     set rule_str = rule %}
+{%   endif %}
+up ip rule add {{ rule_str }}
+down ip rule del {{ rule_str }}
 {% endfor %}
 {% endif %}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -44,29 +44,35 @@ bridge_fd {{ item.fd }}
 bridge-vlan-aware {{ item.vlan_aware }}
 {% endif %}
 
-{% for i in item.route | default([]) %}
+{% if item.route is defined %}
+{%   for i in item.route %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
-{% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
-{% set route = i.network ~ '/' ~ prefix %}
-{% if 'gateway' in i %}
-{% set route = route ~ ' via ' ~ i.gateway %}
-{% else %}
-{% set route = route ~ ' dev ' ~ item.device %}
-{% endif %}
-{% if 'table' in i %}
-{% set route = route ~ ' table ' ~ i.table %}
-{% endif %}
-{% for option in i.options | default([]) %}
-{%   if option is mapping %}
-{%     set option = (option | dict2items | first).key %}
-{%   endif %}
-{%   set route = route ~ ' ' ~ option %}
-{% endfor %}
+{%     if i is mapping %} {# If route is not a mapping, then assume it's a complete rule #}
+{%       set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{%       set route = i.network ~ '/' ~ prefix %}
+{%       if 'gateway' in i %}
+{%         set route = route ~ ' via ' ~ i.gateway %}
+{%       else %}
+{%         set route = route ~ ' dev ' ~ item.device %}
+{%       endif %}
+{%       if 'table' in i %}
+{%         set route = route ~ ' table ' ~ i.table %}
+{%       endif %}
+{%       for option in i.options | default([]) %}
+{%         if option is mapping %}
+{%           set option = (option | dict2items | first).key %}
+{%         endif %}
+{%         set route = route ~ ' ' ~ option %}
+{%       endfor %}
+{%     else %}
+{%       set route = i %}
+{%     endif %}
 up ip route add {{ route }}
 down ip route del {{ route }}
-{% endfor %}
+{%   endfor %}
 
-{%- if item.rules is defined %}
+{% endif %}
+{% if item.rules is defined %}
 {% for rule in item.rules %}
 {%   if rule is mapping %}
 {%     if rule.to is defined %}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -68,7 +68,20 @@ down ip route del {{ route }}
 
 {%- if item.rules is defined %}
 {% for rule in item.rules %}
-up ip rule add {{ rule }}
-down ip rule del {{ rule }}
+{%   if rule is mapping %}
+{%     if rule.to is defined %}
+{%       set rule_str = 'to ' ~ rule.to %}
+{%     endif %}
+{%     if rule.from is defined %}
+{%       set rule_str = 'from ' ~ rule.from %}
+{%     endif %}
+{%     if rule.table is defined %}
+{%       set rule_str = rule_str ~ ' table' ~ rule.table %}
+{%     endif %}
+{%   else %}
+{%     set rule_str = rule %}
+{%   endif %}
+up ip rule add {{ rule_str }}
+down ip rule del {{ rule_str }}
 {% endfor %}
 {% endif %}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -63,13 +63,26 @@ up ip route add {{ route }}
 down ip route del {{ route }}
 {% endfor %}
 {% endif %}
-{% if item.rules is defined %}
-
+{%- if item.rules is defined %}
 {% for rule in item.rules %}
-up ip rule add {{ rule }}
-down ip rule del {{ rule }}
+{%   if rule is mapping %}
+{%     if rule.to is defined %}
+{%       set rule_str = 'to ' ~ rule.to %}
+{%     endif %}
+{%     if rule.from is defined %}
+{%       set rule_str = 'from ' ~ rule.from %}
+{%     endif %}
+{%     if rule.table is defined %}
+{%       set rule_str = rule_str ~ ' table' ~ rule.table %}
+{%     endif %}
+{%   else %}
+{%     set rule_str = rule %}
+{%   endif %}
+up ip rule add {{ rule_str }}
+down ip rule del {{ rule_str }}
 {% endfor %}
 {% endif %}
+
 {% if item.device is match(vlan_interface_regex) %}
 
 vlan-raw-device {{ item.device | regex_replace(vlan_interface_suffix_regex, '') }}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -41,29 +41,34 @@ wpa-conf {{ item.wpaconf }}
 {% endif %}
 
 {% if item.route is defined %}
-{% for i in item.route %}
+{%   for i in item.route %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
-{% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
-{% set route = i.network ~ '/' ~ prefix %}
-{% if 'gateway' in i %}
-{% set route = route ~ ' via ' ~ i.gateway %}
-{% else %}
-{% set route = route ~ ' dev ' ~ item.device %}
-{% endif %}
-{% if 'table' in i %}
-{% set route = route ~ ' table ' ~ i.table %}
-{% endif %}
-{% for option in i.options | default([]) %}
-{%   if option is mapping %}
-{%     set option = (option | dict2items | first).key %}
-{%   endif %}
-{%   set route = route ~ ' ' ~ option %}
-{% endfor %}
+{%     if i is mapping %} {# If route is not a mapping, then assume it's a complete rule #}
+{%       set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{%       set route = i.network ~ '/' ~ prefix %}
+{%       if 'gateway' in i %}
+{%         set route = route ~ ' via ' ~ i.gateway %}
+{%       else %}
+{%         set route = route ~ ' dev ' ~ item.device %}
+{%       endif %}
+{%       if 'table' in i %}
+{%         set route = route ~ ' table ' ~ i.table %}
+{%       endif %}
+{%       for option in i.options | default([]) %}
+{%         if option is mapping %}
+{%           set option = (option | dict2items | first).key %}
+{%         endif %}
+{%         set route = route ~ ' ' ~ option %}
+{%       endfor %}
+{%     else %}
+{%       set route = i %}
+{%     endif %}
 up ip route add {{ route }}
 down ip route del {{ route }}
-{% endfor %}
+{%   endfor %}
+
 {% endif %}
-{%- if item.rules is defined %}
+{% if item.rules is defined %}
 {% for rule in item.rules %}
 {%   if rule is mapping %}
 {%     if rule.to is defined %}

--- a/templates/route_RedHat.j2
+++ b/templates/route_RedHat.j2
@@ -2,6 +2,7 @@
 
 {% for i in item.route | default([]) %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
+{% if i is mapping %} {# If route is not a mapping, then assume it's a complete rule #}
 {% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
 {% set route = i.network ~ '/' ~ prefix %}
 {% if 'gateway' in i %}
@@ -18,5 +19,8 @@
 {%   endif %}
 {%   set route = route ~ ' ' ~ option %}
 {% endfor %}
+{% else %}
+{% set route = i%}
+{% endif %}
 {{ route }}
 {% endfor %}

--- a/templates/route_RedHat.j2
+++ b/templates/route_RedHat.j2
@@ -20,7 +20,7 @@
 {%   set route = route ~ ' ' ~ option %}
 {% endfor %}
 {% else %}
-{% set route = i%}
+{% set route = i %}
 {% endif %}
 {{ route }}
 {% endfor %}


### PR DESCRIPTION
This change gives routes the same behaviour as rules where they can be a mix of strings and hashes and allows setting of rules and routes that don't fit the expected formats. Examples used in the documentation were to configure the rules for a HAproxy setup as per [Transparent Proxying and Binding with HAProxy](https://www.haproxy.com/blog/howto-transparent-proxying-and-binding-with-haproxy-and-aloha-load-balancer/)