### PR TITLE
Update bond_slave_Debian.j2

### DIFF
--- a/templates/bond_slave_Debian.j2
+++ b/templates/bond_slave_Debian.j2
@@ -4,6 +4,6 @@
 
 auto {{ item.1 }}
 iface {{ item.1 }} inet manual
-{% if ansible_facts.distribution_major_version | int < 11 %}
+{% if (ansible_facts.distribution_major_version | int < 11) or (ansible_facts.distribution == 'Ubuntu') %}
 bond-master {{ item.0.device }}
 {% endif %}


### PR DESCRIPTION
https://help.ubuntu.com/community/UbuntuBonding

Hello it looks like ubuntu need bond-master in slaves config thanks i cant get it work without 


cf : https://help.ubuntu.com/community/UbuntuBonding#:~:text=For%20example%2C%20to%20combine%20eth0%20and%20eth1%20as%20slaves%20to%20the%20bonding%20interface%20bond0%20using%20a%20simple%20active%2Dbackup%20setup%2C%20with%20eth0%20being%20the%20primary%20interface