### PR TITLE
Add NetworkManager-config-server rpm to RHEL9

### DIFF
--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -1,4 +1,5 @@
 ---
-interfaces_pkgs: []
+interfaces_pkgs:
+  - NetworkManager-config-server
 
 interfaces_net_path: /etc/NetworkManager/system-connections


### PR DESCRIPTION
It prevents NetworkManager from automatically running DHCP on unconfigured ethernet devices and allows connections with static IP addresses to be brought up even on ethernet devices with no carrier. This is default in Server or Server with GUI RHEL installations.