### PR TITLE
RHEL9 nmconnect templates missing dns-search

### DIFF
--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -106,11 +106,13 @@ dns={{ item.dnsnameservers | join(',') }}
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}
+{% endif %}
 {% if item.dnssearch is defined %}
 {% if item.dnssearch is mapping %}
 dns-search={{ item.dnssearch | join(';') }};
 {% else %}
 dns-search={{ item.dnssearch }}
+{% endif %}
 {% endif %}
 
 [ipv6]

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -101,10 +101,16 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
+{% if item.dnsnameservers is mapping %}
 dns={{ item.dnsnameservers | join(',') }}
+{% else %}
+dns={{ item.dnsnameservers }}
 {% endif %}
 {% if item.dnssearch is defined %}
+{% if item.dnssearch is mapping %}
 dns-search={{ item.dnssearch | join(';') }};
+{% else %}
+dns-search={{ item.dnssearch }}
 {% endif %}
 
 [ipv6]

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -102,7 +102,7 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
 {% if item.dnsnameservers is iterable %}
-dns={{ item.dnsnameservers | join(',') }}
+dns={{ item.dnsnameservers | join(';') }};
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -104,7 +104,7 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 dns={{ item.dnsnameservers | join(',') }}
 {% endif %}
 {% if item.dnssearch is defined %}
-dns-search={{ item.dnssearch | join(',') }}
+dns-search={{ item.dnssearch | join(';') }};
 {% endif %}
 
 [ipv6]

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -101,14 +101,14 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
-{% if item.dnsnameservers is iterable %}
+{% if item.dnsnameservers is not string %}
 dns={{ item.dnsnameservers | join(';') }};
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}
 {% endif %}
 {% if item.dnssearch is defined %}
-{% if item.dnssearch is iterable %}
+{% if item.dnssearch is not string %}
 dns-search={{ item.dnssearch | join(';') }};
 {% else %}
 dns-search={{ item.dnssearch }}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -101,14 +101,14 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
-{% if item.dnsnameservers is mapping %}
+{% if item.dnsnameservers is iterable %}
 dns={{ item.dnsnameservers | join(',') }}
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}
 {% endif %}
 {% if item.dnssearch is defined %}
-{% if item.dnssearch is mapping %}
+{% if item.dnssearch is iterable %}
 dns-search={{ item.dnssearch | join(';') }};
 {% else %}
 dns-search={{ item.dnssearch }}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -103,6 +103,9 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {% if item.dnsnameservers is defined %}
 dns={{ item.dnsnameservers | join(',') }}
 {% endif %}
+{% if item.dnssearch is defined %}
+dns-search={{ item.dnssearch | join(',') }}
+{% endif %}
 
 [ipv6]
 {% if item.ip6 is defined %}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -84,11 +84,13 @@ dns={{ item.dnsnameservers | join(',') }}
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}
+{% endif %}
 {% if item.dnssearch is defined %}
 {% if item.dnssearch is mapping %}
 dns-search={{ item.dnssearch | join(';') }};
 {% else %}
 dns-search={{ item.dnssearch }}
+{% endif %}
 {% endif %}
 
 [ipv6]

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -82,7 +82,7 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 dns={{ item.dnsnameservers | join(',') }}
 {% endif %}
 {% if item.dnssearch is defined %}
-dns-search={{ item.dnssearch | join(',') }}
+dns-search={{ item.dnssearch | join(';') }};
 {% endif %}
 
 [ipv6]

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -79,14 +79,14 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
-{% if item.dnsnameservers is iterable %}
+{% if item.dnsnameservers is not string %}
 dns={{ item.dnsnameservers | join(';') }};
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}
 {% endif %}
 {% if item.dnssearch is defined %}
-{% if item.dnssearch is iterable %}
+{% if item.dnssearch is not string %}
 dns-search={{ item.dnssearch | join(';') }};
 {% else %}
 dns-search={{ item.dnssearch }}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -81,6 +81,9 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {% if item.dnsnameservers is defined %}
 dns={{ item.dnsnameservers | join(',') }}
 {% endif %}
+{% if item.dnssearch is defined %}
+dns-search={{ item.dnssearch | join(',') }}
+{% endif %}
 
 [ipv6]
 {% if item.ip6 is defined %}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -79,14 +79,14 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
-{% if item.dnsnameservers is mapping %}
+{% if item.dnsnameservers is iterable %}
 dns={{ item.dnsnameservers | join(',') }}
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}
 {% endif %}
 {% if item.dnssearch is defined %}
-{% if item.dnssearch is mapping %}
+{% if item.dnssearch is iterable %}
 dns-search={{ item.dnssearch | join(';') }};
 {% else %}
 dns-search={{ item.dnssearch }}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -79,10 +79,16 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
+{% if item.dnsnameservers is mapping %}
 dns={{ item.dnsnameservers | join(',') }}
+{% else %}
+dns={{ item.dnsnameservers }}
 {% endif %}
 {% if item.dnssearch is defined %}
+{% if item.dnssearch is mapping %}
 dns-search={{ item.dnssearch | join(';') }};
+{% else %}
+dns-search={{ item.dnssearch }}
 {% endif %}
 
 [ipv6]

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -80,7 +80,7 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
 {% if item.dnsnameservers is iterable %}
-dns={{ item.dnsnameservers | join(',') }}
+dns={{ item.dnsnameservers | join(';') }};
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -89,6 +89,9 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {% if item.dnsnameservers is defined %}
 dns={{ item.dnsnameservers | join(',') }}
 {% endif %}
+{% if item.dnssearch is defined %}
+dns-search={{ item.dnssearch | join(',') }}
+{% endif %}
 
 [ipv6]
 {% if item.ip6 is defined %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -87,14 +87,14 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
-{% if item.dnsnameservers is iterable %}
+{% if item.dnsnameservers is not string %}
 dns={{ item.dnsnameservers | join(';') }};
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}
 {% endif %}
 {% if item.dnssearch is defined %}
-{% if item.dnssearch is iterable %}
+{% if item.dnssearch is not string %}
 dns-search={{ item.dnssearch | join(';') }};
 {% else %}
 dns-search={{ item.dnssearch }}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -88,7 +88,7 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
 {% if item.dnsnameservers is iterable %}
-dns={{ item.dnsnameservers | join(',') }}
+dns={{ item.dnsnameservers | join(';') }};
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -87,10 +87,16 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
+{% if item.dnsnameservers is mapping %}
 dns={{ item.dnsnameservers | join(',') }}
+{% else %}
+dns={{ item.dnsnameservers }}
 {% endif %}
 {% if item.dnssearch is defined %}
+{% if item.dnssearch is mapping %}
 dns-search={{ item.dnssearch | join(';') }};
+{% else %}
+dns-search={{ item.dnssearch }}
 {% endif %}
 
 [ipv6]

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -92,11 +92,13 @@ dns={{ item.dnsnameservers | join(',') }}
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}
+{% endif %}
 {% if item.dnssearch is defined %}
 {% if item.dnssearch is mapping %}
 dns-search={{ item.dnssearch | join(';') }};
 {% else %}
 dns-search={{ item.dnssearch }}
+{% endif %}
 {% endif %}
 
 [ipv6]

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -87,14 +87,14 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 {%   endif %}
 {% endfor %}
 {% if item.dnsnameservers is defined %}
-{% if item.dnsnameservers is mapping %}
+{% if item.dnsnameservers is iterable %}
 dns={{ item.dnsnameservers | join(',') }}
 {% else %}
 dns={{ item.dnsnameservers }}
 {% endif %}
 {% endif %}
 {% if item.dnssearch is defined %}
-{% if item.dnssearch is mapping %}
+{% if item.dnssearch is iterable %}
 dns-search={{ item.dnssearch | join(';') }};
 {% else %}
 dns-search={{ item.dnssearch }}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -90,7 +90,7 @@ routing-rule{{ loop.index }}=priority {{ 32765 - loop.index0 }} {{ rule }}
 dns={{ item.dnsnameservers | join(',') }}
 {% endif %}
 {% if item.dnssearch is defined %}
-dns-search={{ item.dnssearch | join(',') }}
+dns-search={{ item.dnssearch | join(';') }};
 {% endif %}
 
 [ipv6]


### PR DESCRIPTION
The nmconnect templates for RHEL9 were missing the bits to set the `dns-search` setting for RHEL9 Network Manager 

I've added these, they're a semicolon separated & terminated list