### PR TITLE
Update Galaxi metadata to use galaxy_tags

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,6 @@ galaxy_info:
     - name: Fedora
       versions:
         - all
-  categories:
+  galaxy_tags:
     - system
 dependencies: []


### PR DESCRIPTION
categories is no longer supported.
