### PR TITLE
Add starting NM in tasks/service.yml

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -13,3 +13,13 @@
   when:
     - ansible_facts.os_family == 'RedHat'
     - not interfaces_use_networkmanager
+
+- name: RedHat | ensure NetworkManager service is started and enabled
+  become: true
+  service:
+    name: NetworkManager
+    enabled: true
+    state: started
+  when:
+    - ansible_facts.os_family == 'RedHat'
+    - interfaces_use_networkmanager


### PR DESCRIPTION
It allows to properly configure use this role on at least RHEL8, without that it returns an error during bouncing of NetworkManager.