### PR TITLE
Fix for IPv4 assignment made as secondary address

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -76,12 +76,13 @@ def _interface_check(context, interface, interface_type=None):
             if not fact_address:
                 if not secondaries:
                     return _fail("Interface %s has no IPv4 address" % device)
-                else:
-                    for address_dict in secondaries:
-                        if interface['address'] == address_dict['address']:
-                            fact['ipv4'] = address_dict
-                            fact_address = address_dict['address']
-                            break
+
+            if secondaries:
+                for address_dict in secondaries:
+                    if interface['address'] == address_dict['address']:
+                        fact['ipv4'] = address_dict
+                        fact_address = address_dict['address']
+
             if fact_address != interface["address"]:
                 return _fail("Interface %s has incorrect IPv4 address" % device)
 


### PR DESCRIPTION
In circumstances where the IPv4 address assigned by this role appears as a secondary IP assignment, validate the secondary assignment instead of a primary one.

A secondary address appears to be equally as valid as a primary address assignment, and apparently in some circumstances MichaelRigart.interfaces can make a secondary address assignment.