### PR TITLE
Fix dummy interface regex

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,4 +8,4 @@ vlan_interface_regex: '(?P<interface>.*)\.(?P<vlan_id>\d{1,4})'
 vlan_interface_suffix_regex: '\.\d{1,4}'
 
 # Regular expression matching a dummy interface base on name
-dummy_interface_regex: 'dummy*'
+dummy_interface_regex: 'dummy.*'


### PR DESCRIPTION
The `dummy*` regex would match `dumm` and `dummy`, which worked because it is used with the Ansible match test, which succeeds if it finds the pattern at the beginning of the string.

Use the proper regex for correctness.