### PR TITLE
Allow ignoring interface status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ interfaces_setup_gather_subset: "{{ omit }}"
 # An option to merge all configurations setup with merge: true
 # in the global interfaces file (Debian-Family only)
 interfaces_merge: false
+
+# An option that does not fail interfaces bounce action when an
+# error has occured - useful when you assume one of the interfaces
+# to not have proper state.
+interfaces_bounce_ignore_errors: false
 ```
 
 Note: The values for the list are listed in the examples below.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,4 @@ interfaces_setup_filter: "{{ omit }}"
 interfaces_setup_gather_subset: "{{ omit }}"
 interfaces_bond_setup_slaves: true
 interfaces_merge: false
+interfaces_bounce_ignore_errors: false

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -58,7 +58,7 @@ def _interface_check(context, interface, interface_type=None):
     # secondary IP addresses on another interface.
     if ':' not in device:
         # State
-        if not fact.get("active"):
+        if not fact.get("active") and not bool(interface.get("ignore_status_check")):
             return _fail("Interface %s is not active" % device)
 
         # Type

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -127,7 +127,9 @@
     {% for interface in all_interfaces_changed %}
     if ! nmcli connection up {{ interface }}; then
       echo \"Failed to bring up interface {{ interface }}\";
+      {% if interfaces_bounce_ignore_errors | bool %}
       returncode=1
+      {% endif %}
     fi;
     {% endfor %}
 
@@ -145,7 +147,9 @@
         all_connected=false
         if [ $i -eq 20 ]; then
           echo 'Interface {{ interface }} failed to become active and have a connected carrier';
+          {% if interfaces_bounce_ignore_errors | bool %}
           returncode=1
+          {% endif %}
         fi
       fi;
       {% endfor %}
@@ -201,7 +205,9 @@
     {% for interface in all_interfaces_changed %}
     if ! ifup {% if ansible_facts.os_family == 'Debian' %}--allow auto {% endif %}{{ interface }}; then
       echo \"Failed to bring up interface {{ interface }}\";
+      {% if interfaces_bounce_ignore_errors | bool %}
       returncode=1
+      {% endif %}
     fi;
     {% endfor %}
 


### PR DESCRIPTION
This patch introduces a new variable called interfaces_bounce_ignore_errors that allows to ignore errors during interface bounce (such as interfaces in down state without a link).

It also introduces a new interface variable that is called ignore_status_check that allows to ignore interfaces with down state during interfaces check.