### PR TITLE
Add support for managing loopback devices with Network Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,8 @@ bouncing network interfaces before they are active. This can be done by setting
 ```
 
 18) Routes and rules can be a mix of strings and hashes (a.k.a. dict, mapping, associative array, etc.) allowing
-    the role to handle rules and routes outside the expected formats.
+    the role to handle rules and routes outside the expected formats. These can also be applied to loopback devices in
+    distributions using Network Manager's new `nmconnect` configuration files (e.g. RHEL8 & RHEL9).
 
     The example below configures an interface, to act as a second interface so that any traffic that hits it is returned via the same interface. In addition internal traffic is marked so it can be picked up by some other service (like HAproxy).
 
@@ -469,11 +470,19 @@ interfaces_ether_interfaces:
           network: 0.0.0.0
           netmask: 0.0.0.0
           gateway: 10.10.10.254
-        - "local 0.0.0.0/0 dev lo table marktable"
       rules:
         - from: 10.10.10.1
           table: frontend
         - "fwmark 1 lookup marktable"
+    - device: lo
+      type: loopback
+      # Setting bootproto to dhcp is required to set `method=auto` in the nmconnect file
+      bootproto: dhcp
+      route:
+        - table: marktable
+          device: lo
+          network: 0.0.0.0
+          netmask: 0
 ```
 
 Example Playbook

--- a/README.md
+++ b/README.md
@@ -477,12 +477,15 @@ interfaces_ether_interfaces:
     - device: lo
       type: loopback
       # Setting bootproto to dhcp is required to set `method=auto` in the nmconnect file
+      # This replicates `ip route add local 0.0.0.0/0 dev lo table 100"`
       bootproto: dhcp
       route:
         - table: marktable
           device: lo
           network: 0.0.0.0
           netmask: 0
+          options:
+            - type: local
 ```
 
 Example Playbook

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -102,20 +102,20 @@ def _interface_check(context, interface, interface_type=None):
         elif fact_address and fact_address not in interface.get('allowed_addresses', []):
             return _fail("Interface %s has an IPv4 address but none was "
                          "requested" % device)
-    
+
     # Static IPv6 address
     if interface.get("bootproto") == "static" and interface.get("ip6"):
         fact_address = fact.get("ipv6", [])
         # IP address
         if len(fact_address) == 0:
             return _fail("Interface %s has no IPv6 address" % device)
-        
+
         for item in fact_address:
             if item["address"] == interface["ip6"]["address"] and item["prefix"] == str(interface["ip6"]["prefix"]):
                 break
         else:
             return _fail("Interface %s has incorrect IPv6 address" % device)
-        
+
         # Gateway
         if interface["ip6"].get("gateway"):
             fact_gateway = context["ansible_facts"].get("default_ipv6", {}).get("gateway")
@@ -143,6 +143,8 @@ def ether_check(context, interface):
     """
     if interface.get('type') == 'ipoib':
         result = _interface_check(context, interface, "infiniband")
+    elif interface.get('type') == 'loopback':
+        result = _interface_check(context, interface, "loopback")
     else:
         result = _interface_check(context, interface, "ether")
     return result

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -137,6 +137,8 @@
       {% for interface in all_interfaces_changed %}
       if [[ '{{ interface }}' == *dummy* ]]; then
         allowed_states='UNKNOWN|UP'
+      elif [[ '{{ interface }}' == 'lo' ]]; then
+        allowed_states='UNKNOWN'
       else
         allowed_states='UP'
       fi

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -2,7 +2,11 @@
 
 [connection]
 id={{ item.device }}
+{% if 'type' in item %}
+type={{ item.type }}
+{% else %}
 type={{ ('vlan' if item.device is match(vlan_interface_regex) else 'dummy' if item.device is match(dummy_interface_regex) else 'ethernet') }}
+{% endif %}
 interface-name={{ item.device }}
 {% if item.zone is defined %}
 zone={{ item.zone }}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -31,6 +31,12 @@ parent={{ item.device | regex_replace(vlan_interface_regex, '\g<interface>') }}
 id={{ item.device | regex_replace(vlan_interface_regex, '\g<vlan_id>') }}
 {% endif %}
 
+{% if 'type' in item %}
+{% if item.type == 'loopback' %}
+[loopback]
+
+{% endif %}
+{% endif %}
 [ipv4]
 {% if item.bootproto == 'dhcp' %}
 method=auto


### PR DESCRIPTION
This addresses Issue #162 

Updates the `ethernet_nmconnect.j2` template to handle loopback devices, and updates the ether checks to pass them.

It should work for the default `lo` loopback device, but might need more work to handle other loopback devices if configured.