### PR TITLE
Fix routing tables on recent CentOS Stream 9

### DIFF
--- a/tasks/route_table_configuration.yml
+++ b/tasks/route_table_configuration.yml
@@ -1,8 +1,21 @@
 ---
+- name: Ensure /etc/iproute2 directory exists
+  become: true
+  ansible.builtin.file:
+    path: /etc/iproute2
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
 - name: Ensure IP routing tables are defined
   become: true
   blockinfile:
+    create: true
     dest: /etc/iproute2/rt_tables
+    owner: root
+    group: root
+    mode: '0644'
     block: |
       {% for table in interfaces_route_tables %}
       {{ table.id }} {{ table.name }}


### PR DESCRIPTION
Recent versions of the iproute package in CentOS Stream 9 do not include /etc/iproute2/rt_tables but use /usr/share/iproute2/rt_tables instead. As a result, routing table configuration fails because it cannot write to /etc/iproute2/rt_tables.

Ensure this file and its parent directory exist, since it is still supported and takes precedence over /usr/share/iproute2/rt_tables.