### PR TITLE
Fix usage of ipaddr filter

### DIFF
--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -66,7 +66,7 @@ bond-slaves {{ item.bond_slaves|join(' ') }}
 {%   for i in item.route %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
 {%     if i is mapping %} {# If route is not a mapping, then assume it's a complete rule #}
-{%       set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{%       set prefix = ('0.0.0.0/' ~ i.netmask) | ansible.utils.ipaddr('prefix') %}
 {%       set route = i.network ~ '/' ~ prefix %}
 {%       if 'gateway' in i %}
 {%         set route = route ~ ' via ' ~ i.gateway %}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -47,7 +47,7 @@ method=auto
 {% elif item.bootproto == 'static' and item.address is defined and item.address | length %}
 method=manual
 {%   if item.netmask is defined %}
-address1={{ (item.address ~'/'~ item.netmask) | ipaddr('host/prefix') }}
+address1={{ (item.address ~'/'~ item.netmask) | ansible.utils.ipaddr('host/prefix') }}
 {%   endif %}
 {%   if item.gateway is defined and item.gateway | length %}
 gateway={{ item.gateway }}
@@ -72,9 +72,9 @@ method=disabled
 {%     endif %}
 {%   endfor %}
 {%   if 'gateway' in route %}
-{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') ~ ',' ~ route.gateway %}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ansible.utils.ipaddr('network/prefix') ~ ',' ~ route.gateway %}
 {%   else %}
-{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') %}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ansible.utils.ipaddr('network/prefix') %}
 {%   endif %}
 route{{ loop.index }}={{ route_string }}
 {%   if 'table' in route %}
@@ -108,14 +108,14 @@ dns={{ item.dnsnameservers | join(',') }}
 {% if item.ip6 is defined %}
 method={{ (item.bootproto == 'static') | ternary('manual', 'auto') }}
 {%   if item.ip6.address is defined and item.ip6.netmask is defined %}
-address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ipaddr('host/prefix') }}
+address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ansible.utils.ipaddr('host/prefix') }}
 {%   endif %}
 {%   if item.ip6.gateway is defined %}
 gateway={{ item.ip6.gateway }}
 {%   endif %}
 {%   for route in item.ip6.route | default([]) %}
 {%     if 'gateway' in route %}
-route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ansible.utils.ipaddr('network/prefix') }},{{ route.gateway }}
 {%     endif %}
 {#     TODO: dev, table, options #}
 {%   endfor %}

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -48,7 +48,7 @@ bridge-vlan-aware {{ item.vlan_aware }}
 {%   for i in item.route %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
 {%     if i is mapping %} {# If route is not a mapping, then assume it's a complete rule #}
-{%       set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{%       set prefix = ('0.0.0.0/' ~ i.netmask) | ansible.utils.ipaddr('prefix') %}
 {%       set route = i.network ~ '/' ~ prefix %}
 {%       if 'gateway' in i %}
 {%         set route = route ~ ' via ' ~ i.gateway %}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -25,7 +25,7 @@ method=auto
 {% elif item.bootproto == 'static' and item.address is defined and item.address | length %}
 method=manual
 {%   if item.netmask is defined %}
-address1={{ (item.address ~'/'~ item.netmask) | ipaddr('host/prefix') }}
+address1={{ (item.address ~'/'~ item.netmask) | ansible.utils.ipaddr('host/prefix') }}
 {%   endif %}
 {%   if item.gateway is defined and item.gateway | length %}
 gateway={{ item.gateway }}
@@ -50,9 +50,9 @@ method=disabled
 {%     endif %}
 {%   endfor %}
 {%   if 'gateway' in route %}
-{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') ~ ',' ~ route.gateway %}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ansible.utils.ipaddr('network/prefix') ~ ',' ~ route.gateway %}
 {%   else %}
-{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') %}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ansible.utils.ipaddr('network/prefix') %}
 {%   endif %}
 route{{ loop.index }}={{ route_string }}
 {%   if 'table' in route %}
@@ -86,14 +86,14 @@ dns={{ item.dnsnameservers | join(',') }}
 {% if item.ip6 is defined %}
 method={{ (item.bootproto == 'static') | ternary('manual', 'auto') }}
 {%   if item.ip6.address is defined and item.ip6.netmask is defined %}
-address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ipaddr('host/prefix') }}
+address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ansible.utils.ipaddr('host/prefix') }}
 {%   endif %}
 {%   if item.ip6.gateway is defined %}
 gateway={{ item.ip6.gateway }}
 {%   endif %}
 {%   for route in item.ip6.route | default([]) %}
 {%     if 'gateway' in route %}
-route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ansible.utils.ipaddr('network/prefix') }},{{ route.gateway }}
 {%     endif %}
 {#     TODO: dev, table, options #}
 {%   endfor %}

--- a/templates/ethernet_Debian.j2
+++ b/templates/ethernet_Debian.j2
@@ -44,7 +44,7 @@ wpa-conf {{ item.wpaconf }}
 {%   for i in item.route %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
 {%     if i is mapping %} {# If route is not a mapping, then assume it's a complete rule #}
-{%       set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{%       set prefix = ('0.0.0.0/' ~ i.netmask) | ansible.utils.ipaddr('prefix') %}
 {%       set route = i.network ~ '/' ~ prefix %}
 {%       if 'gateway' in i %}
 {%         set route = route ~ ' via ' ~ i.gateway %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -33,7 +33,7 @@ method=auto
 {% elif item.bootproto == 'static' and item.address is defined and item.address | length %}
 method=manual
 {%   if item.netmask is defined %}
-address1={{ (item.address ~'/'~ item.netmask) | ipaddr('host/prefix') }}
+address1={{ (item.address ~'/'~ item.netmask) | ansible.utils.ipaddr('host/prefix') }}
 {%   endif %}
 {%   if item.gateway is defined and item.gateway | length %}
 gateway={{ item.gateway }}
@@ -58,9 +58,9 @@ method=disabled
 {%     endif %}
 {%   endfor %}
 {%   if 'gateway' in route %}
-{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') ~ ',' ~ route.gateway %}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ansible.utils.ipaddr('network/prefix') ~ ',' ~ route.gateway %}
 {%   else %}
-{%     set route_string = (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') %}
+{%     set route_string = (route.network ~'/'~ route.netmask) | ansible.utils.ipaddr('network/prefix') %}
 {%   endif %}
 route{{ loop.index }}={{ route_string }}
 {%   if 'table' in route %}
@@ -94,14 +94,14 @@ dns={{ item.dnsnameservers | join(',') }}
 {% if item.ip6 is defined %}
 method={{ (item.bootproto == 'static') | ternary('manual', 'auto') }}
 {%   if item.ip6.address is defined and item.ip6.netmask is defined %}
-address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ipaddr('host/prefix') }}
+address1={{ (item.ip6.address ~'/'~ item.ip6.netmask) | ansible.utils.ipaddr('host/prefix') }}
 {%   endif %}
 {%   if item.ip6.gateway is defined %}
 gateway={{ item.ip6.gateway }}
 {%   endif %}
 {%   for route in item.ip6.route | default([]) %}
 {%     if 'gateway' in route %}
-route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ipaddr('network/prefix') }},{{ route.gateway }}
+route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ansible.utils.ipaddr('network/prefix') }},{{ route.gateway }}
 {%     endif %}
 {#     TODO: dev, table, options #}
 {%   endfor %}

--- a/templates/route_RedHat.j2
+++ b/templates/route_RedHat.j2
@@ -3,7 +3,7 @@
 {% for i in item.route | default([]) %}
 {# Workaround for Ansible bug https://github.com/ansible/ansible/issues/17872. #}
 {% if i is mapping %}{# If route is not a mapping, then assume it's a complete rule #}
-{% set prefix = ('0.0.0.0/' ~ i.netmask) | ipaddr('prefix') %}
+{% set prefix = ('0.0.0.0/' ~ i.netmask) | ansible.utils.ipaddr('prefix') %}
 {% set route = i.network ~ '/' ~ prefix %}
 {% if 'gateway' in i %}
 {% set route = route ~ ' via ' ~ i.gateway %}


### PR DESCRIPTION
When evaluating the templates, an error is raised failing to load ``ipaddr``. Fix this by specifying the full name of the collection.

```
ansible.errors.AnsibleError: template error while templating string: Could not load "ipaddr": 'ipaddr'.
```