### PR TITLE
Fix regression in bond where type was required

### DIFF
--- a/templates/bond_slave_nmconnection.j2
+++ b/templates/bond_slave_nmconnection.j2
@@ -2,8 +2,9 @@
 
 [connection]
 id={{ item.1 }}
-{% if item.0.type == 'ipoib' %}
-type=infiniband
+{% if 'type' in item.0 %}
+{%- set type_map = {'ipoib': 'infiniband'} -%}
+type={{ type_map[item.0.type] | default(item.0.type) }}
 {% else %}
 type={{ (item.1 is match(dummy_interface_regex)) | ternary('dummy', 'ethernet') }}
 {% endif %}


### PR DESCRIPTION
- Fixes autodetection of type for bonds
- Makes the jinja templating consistent with the regular interface so you can set any type manually
