### PR TITLE
Allow management of /etc/NetworkManager/conf.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ interfaces_merge: false
 # error has occured - useful when you assume one of the interfaces
 # to not have proper state.
 interfaces_bounce_ignore_errors: false
+
+# Creates configuration files in `/etc/NetworkManager/conf.d`
+interfaces_networkmanager_configs: {}
 ```
 
 Note: The values for the list are listed in the examples below.
@@ -492,6 +495,23 @@ interfaces_ether_interfaces:
           options:
             - type: local
 ```
+
+19) Some network configurations may require changing how Network Manager behaves and this can be done using the `interfaces_networkmanager_configs` variable to define the `.ini` style files that are expected in `/etc/NetworkManager/conf.d`. This variable does no validation or checking and will create the files as specified.
+
+```yaml
+interfaces_networkmanager_configs:
+  90-dns-none.conf:
+    main:
+      dns: 'none'
+```
+
+Will create the file `/etc/networkmanager/conf.d/90-dns-none.conf` with the content:
+
+```ini
+[main]
+dns=none
+```
+Which will block Network Manager from updating `/etc/resolv.conf` as per [Redhat Documentation on disabling DNS processing for Network Manager](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/manually-configuring-the-etc-resolv-conf-file_configuring-and-managing-networking)
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 interfaces_use_networkmanager: "{{ ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version | int >= 9 }}"
 interfaces_use_nmconnection: "{{ ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version | int >= 9 }}"
 
+interfaces_networkmanager_configs: {}
+
 interfaces_pkg_state: present
 interfaces_route_tables: []
 interfaces_ether_interfaces: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,9 @@
 
 - include_tasks: "{{ ansible_facts.os_family | lower }}.yml"
 
+- import_tasks: 'networkmanager_configs.yml'
+  tags: configuration
+
 - import_tasks: 'route_table_configuration.yml'
   tags: configuration
 

--- a/tasks/networkmanager_configs.yml
+++ b/tasks/networkmanager_configs.yml
@@ -4,8 +4,8 @@
     dest: "{{ interfaces_nm_config_path }}/{{ item.key}}"
     owner: root
     group: root
-    permissions: '0640'
+    mode: '0640'
     content: "{{ item.value | community.general.to_ini }}"
   notify: Reload NetworkManager
-  loop: "{{ lookup('dict', interfaces_networkmanager_configs) }}"
+  loop: "{{ lookup('dict', interfaces_networkmanager_configs, wantlist=True) }}"
   tags: configurations

--- a/tasks/networkmanager_configs.yml
+++ b/tasks/networkmanager_configs.yml
@@ -6,5 +6,6 @@
     group: root
     permissions: '0640'
     content: "{{ item.value | community.general.to_ini }}"
+  notify: Reload NetworkManager
   loop: "{{ lookup('dict', interfaces_networkmanager_configs) }}"
   tags: configurations

--- a/tasks/networkmanager_configs.yml
+++ b/tasks/networkmanager_configs.yml
@@ -1,0 +1,10 @@
+---
+- name: Create NetworkManager configurations
+  ansible.builtin.copy:
+    dest: "{{ interfaces_nm_config_path }}/{{ item.key}}"
+    owner: root
+    group: root
+    permissions: '0640'
+    content: "{{ item.value | community.general.to_ini }}"
+  loop: "{{ lookup('dict', interfaces_networkmanager_configs) }}"
+  tags: configurations

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -8,3 +8,4 @@ interfaces_pkgs:
   - resolvconf
 
 interfaces_net_path: /etc/network/interfaces.d
+interfaces_nm_config_path: /etc/NetworkManager/conf.d

--- a/vars/redhat-10.yml
+++ b/vars/redhat-10.yml
@@ -3,3 +3,4 @@ interfaces_pkgs:
   - NetworkManager-config-server
 
 interfaces_net_path: /etc/NetworkManager/system-connections
+interfaces_nm_config_path: /etc/NetworkManager/conf.d

--- a/vars/redhat-7.yml
+++ b/vars/redhat-7.yml
@@ -6,3 +6,4 @@ interfaces_pkgs:
   - libselinux-python
 
 interfaces_net_path: /etc/sysconfig/network-scripts
+interfaces_nm_config_path: /etc/NetworkManager/conf.d

--- a/vars/redhat-8.yml
+++ b/vars/redhat-8.yml
@@ -6,3 +6,4 @@ interfaces_pkgs:
   - network-scripts
 
 interfaces_net_path: "{{ interfaces_use_nmconnection | ternary('/etc/NetworkManager/system-connections', '/etc/sysconfig/network-scripts') }}"
+interfaces_nm_config_path: /etc/NetworkManager/conf.d

--- a/vars/redhat-9.yml
+++ b/vars/redhat-9.yml
@@ -3,3 +3,4 @@ interfaces_pkgs:
   - NetworkManager-config-server
 
 interfaces_net_path: /etc/NetworkManager/system-connections
+interfaces_nm_config_path: /etc/NetworkManager/conf.d


### PR DESCRIPTION
Sets up a list of dicts that can be used to manage the `/etc/NetworkManager/conf.d` contents allowing to set things like disabling NetworkManager from managing `/etc/resolv.conf` as per the example provided in the documentation,