### PR TITLE
Rocky9 update nmconnect templates

### DIFF
--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -18,9 +18,17 @@ slave-type=bridge
 {%   endif %}
 {% endfor %}
 
+{% if item.type | default('ethernet')  == 'ipoib' %}
+[infiniband]
+transport-mode=datagram
+{% if item.mtu is defined %}
+mtu={{ item.mtu }}
+{% endif %}
+{% else %}
 {% if item.mtu is defined %}
 [ethernet]
 mtu={{ item.mtu }}
+{% endif %}
 {% endif %}
 
 [bond]

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -66,6 +66,9 @@ address1={{ (item.address ~'/'~ item.netmask) | ansible.utils.ipaddr('host/prefi
 {%   if item.gateway is defined and item.gateway | length %}
 gateway={{ item.gateway }}
 {%   endif %}
+{% if item.defroute is defined and not item.defroute%}
+never-default=true
+{% endif %}
 {% else %}
 method=disabled
 {% endif %}
@@ -144,6 +147,9 @@ route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ansible.utils.ipa
 {%     endif %}
 {#     TODO: dev, table, options #}
 {%   endfor %}
+{% if item.defroute is defined and not item.defroute%}
+never-default=true
+{% endif %}
 {% else %}
 method=disabled
 {% endif %}

--- a/templates/bond_nmconnection.j2
+++ b/templates/bond_nmconnection.j2
@@ -18,17 +18,11 @@ slave-type=bridge
 {%   endif %}
 {% endfor %}
 
-{% if item.type | default('ethernet')  == 'ipoib' %}
-[infiniband]
-transport-mode=datagram
-{% if item.mtu is defined %}
-mtu={{ item.mtu }}
-{% endif %}
-{% else %}
+
+{# note that a bond interface is virtually ethernet even if the ports are infiniband #}
 {% if item.mtu is defined %}
 [ethernet]
 mtu={{ item.mtu }}
-{% endif %}
 {% endif %}
 
 [bond]

--- a/templates/bond_slave_nmconnection.j2
+++ b/templates/bond_slave_nmconnection.j2
@@ -15,8 +15,8 @@ port-type=bond
 {% if item.0.type | default('ethernet')  == 'ipoib' %}
 [infiniband]
 transport-mode=datagram
-{% if item.mtu is defined %}
-mtu={{ item.mtu }}
+{% if item.0.mtu is defined %}
+mtu={{ item.0.mtu }}
 {% endif %}
 {% else %}
 {% if item.0.mtu is defined %}

--- a/templates/bond_slave_nmconnection.j2
+++ b/templates/bond_slave_nmconnection.j2
@@ -9,6 +9,20 @@ type={{ type_map[item.0.type] | default(item.0.type) }}
 type={{ (item.1 is match(dummy_interface_regex)) | ternary('dummy', 'ethernet') }}
 {% endif %}
 interface-name={{ item.1 }}
+controller={{ item.0.device }}
+port-type=bond
 
-master={{ item.0.device }}
-slave-type=bond
+{% if item.type | default('ethernet')  == 'ipoib' %}
+[infiniband]
+transport-mode=datagram
+{% if item.mtu is defined %}
+mtu={{ item.mtu }}
+{% endif %}
+{% else %}
+{% if item.mtu is defined %}
+[ethernet]
+mtu={{ item.mtu }}
+{% endif %}
+{% endif %}
+
+[bond-port]

--- a/templates/bond_slave_nmconnection.j2
+++ b/templates/bond_slave_nmconnection.j2
@@ -12,14 +12,14 @@ interface-name={{ item.1 }}
 controller={{ item.0.device }}
 port-type=bond
 
-{% if item.type | default('ethernet')  == 'ipoib' %}
+{% if item.0.type | default('ethernet')  == 'ipoib' %}
 [infiniband]
 transport-mode=datagram
 {% if item.mtu is defined %}
 mtu={{ item.mtu }}
 {% endif %}
 {% else %}
-{% if item.mtu is defined %}
+{% if item.0.mtu is defined %}
 [ethernet]
 mtu={{ item.mtu }}
 {% endif %}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -38,6 +38,9 @@ address1={{ (item.address ~'/'~ item.netmask) | ansible.utils.ipaddr('host/prefi
 {%   if item.gateway is defined and item.gateway | length %}
 gateway={{ item.gateway }}
 {%   endif %}
+{% if item.defroute is defined and not item.defroute%}
+never-default=true
+{% endif %}
 {% else %}
 method=disabled
 {% endif %}
@@ -116,6 +119,9 @@ route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ansible.utils.ipa
 {%     endif %}
 {#     TODO: dev, table, options #}
 {%   endfor %}
+{% if item.defroute is defined and not item.defroute%}
+never-default=true
+{% endif %}
 {% else %}
 method=disabled
 {% endif %}

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -8,17 +8,10 @@ interface-name={{ item.device }}
 zone={{ item.zone }}
 {% endif %}
 
-{% if item.type | default('ethernet')  == 'ipoib' %}
-[infiniband]
-transport-mode=datagram
-{% if item.mtu is defined %}
-mtu={{ item.mtu }}
-{% endif %}
-{% else %}
+{# note that a bridge interface is virtually ethernet even if it's ports are not #}
 {% if item.mtu is defined %}
 [ethernet]
 mtu={{ item.mtu }}
-{% endif %}
 {% endif %}
 
 [bridge]

--- a/templates/bridge_nmconnection.j2
+++ b/templates/bridge_nmconnection.j2
@@ -8,9 +8,17 @@ interface-name={{ item.device }}
 zone={{ item.zone }}
 {% endif %}
 
+{% if item.type | default('ethernet')  == 'ipoib' %}
+[infiniband]
+transport-mode=datagram
+{% if item.mtu is defined %}
+mtu={{ item.mtu }}
+{% endif %}
+{% else %}
 {% if item.mtu is defined %}
 [ethernet]
 mtu={{ item.mtu }}
+{% endif %}
 {% endif %}
 
 [bridge]

--- a/templates/bridge_port_nmconnection.j2
+++ b/templates/bridge_port_nmconnection.j2
@@ -4,13 +4,20 @@
 id={{ item.1 }}
 type={{ ('vlan' if item.1 is match(vlan_interface_regex) else 'dummy' if item.1 is match(dummy_interface_regex) else 'ethernet') }}
 interface-name={{ item.1 }}
+controller={{ item.0.device }}
+port-type=bridge
 
-master={{ item.0.device }}
-slave-type=bridge
-
-{% if item.0.mtu is defined %}
+{% if item.type | default('ethernet')  == 'ipoib' %}
+[infiniband]
+transport-mode=datagram
+{% if item.mtu is defined %}
+mtu={{ item.mtu }}
+{% endif %}
+{% else %}
+{% if item.mtu is defined %}
 [ethernet]
-mtu={{ item.0.mtu }}
+mtu={{ item.mtu }}
+{% endif %}
 {% endif %}
 
 {% if item.1 is match(vlan_interface_regex) %}

--- a/templates/bridge_port_nmconnection.j2
+++ b/templates/bridge_port_nmconnection.j2
@@ -11,12 +11,12 @@ port-type=bridge
 [infiniband]
 transport-mode=datagram
 {% if item.mtu is defined %}
-mtu={{ item.mtu }}
+mtu={{ item.0.mtu }}
 {% endif %}
 {% else %}
 {% if item.0.mtu is defined %}
 [ethernet]
-mtu={{ item.mtu }}
+mtu={{ item.0.mtu }}
 {% endif %}
 {% endif %}
 

--- a/templates/bridge_port_nmconnection.j2
+++ b/templates/bridge_port_nmconnection.j2
@@ -7,14 +7,14 @@ interface-name={{ item.1 }}
 controller={{ item.0.device }}
 port-type=bridge
 
-{% if item.type | default('ethernet')  == 'ipoib' %}
+{% if item.0.type | default('ethernet')  == 'ipoib' %}
 [infiniband]
 transport-mode=datagram
 {% if item.mtu is defined %}
 mtu={{ item.mtu }}
 {% endif %}
 {% else %}
-{% if item.mtu is defined %}
+{% if item.0.mtu is defined %}
 [ethernet]
 mtu={{ item.mtu }}
 {% endif %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -63,6 +63,9 @@ address1={{ (item.address ~'/'~ item.netmask) | ansible.utils.ipaddr('host/prefi
 {%   if item.gateway is defined and item.gateway | length %}
 gateway={{ item.gateway }}
 {%   endif %}
+{% if item.defroute is defined and not item.defroute%}
+never-default=true
+{% endif %}
 {% else %}
 method=disabled
 {% endif %}
@@ -141,6 +144,9 @@ route{{ loop.index }}={{ (route.network ~'/'~ route.netmask) | ansible.utils.ipa
 {%     endif %}
 {#     TODO: dev, table, options #}
 {%   endfor %}
+{% if item.defroute is defined and not item.defroute%}
+never-default=true
+{% endif %}
 {% else %}
 method=disabled
 {% endif %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -15,19 +15,22 @@ zone={{ item.zone }}
 
 {% for bridge in interfaces_bridge_interfaces %}
 {%   if item.device in bridge.ports %}
-master={{ bridge.device }}
-slave-type=bridge
+controller={{ bridge.device }}
+port-type=bridge
 {%   endif %}
 {% endfor %}
-
-{% if item.mtu is defined %}
-[ethernet]
-mtu={{ item.mtu }}
-{% endif %}
 
 {% if item.type | default('ethernet')  == 'ipoib' %}
 [infiniband]
 transport-mode=datagram
+{% if item.mtu is defined %}
+mtu={{ item.mtu }}
+{% endif %}
+{% else %}
+{% if item.mtu is defined %}
+[ethernet]
+mtu={{ item.mtu }}
+{% endif %}
 {% endif %}
 
 {% if item.device is match(vlan_interface_regex) %}


### PR DESCRIPTION
This addresses #180 

- Uses `controller` and `port` rather than now deprecated `master` and `slave`
- Properly configures `[infiniband]` settings separate from `[ethernet]`
- Casts bonds and bridges as `[ethernet]` even if the ports are infiniband
- Sets `never-default=true` in `[ipv4]` and `[ipv6]` settings if `defroute` is false