### PR TITLE
Prefer infiniband over ipoib for interface type

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,9 +343,9 @@ which should be a list.
                - metric 400
 ```
 
-12) Configure an IPoIB (infiniband) interface
+12) Configure an IPoIB / Infiniband interface
 
-Configuring an IPoIB interface is possible using `type: ipoib` when defining the interface.
+Configuring an Infiniband interface is possible using `type: infiniband` when defining the interface. `type: ipoib` is still accepted as an alias.
 
 **WARNING: You can configure the ip address and routes for an IPoIB interface but other functionalities like vlans are not supported in infiniband networks**
 
@@ -363,7 +363,7 @@ Configuring an IPoIB interface is possible using `type: ipoib` when defining the
           bootproto: static
           address: 10.10.1.10
           netmask: 255.255.255.0
-          type: ipoib
+          type: infiniband
 ```
 
 13) Configure ethtool options (RedHat-family only)

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -141,7 +141,7 @@ def ether_check(context, interface):
     :param interface: An item in interfaces_ether_interfaces.
     :returns: A dict containing 'diff' and 'reason' items.
     """
-    if interface.get('type') == 'ipoib':
+    if interface.get('type') in ('ipoib', 'infiniband'):
         result = _interface_check(context, interface, "infiniband")
     elif interface.get('type') == 'loopback':
         result = _interface_check(context, interface, "loopback")

--- a/templates/bond_slave_nmconnection.j2
+++ b/templates/bond_slave_nmconnection.j2
@@ -12,7 +12,7 @@ interface-name={{ item.1 }}
 controller={{ item.0.device }}
 port-type=bond
 
-{% if item.0.type | default('ethernet')  == 'ipoib' %}
+{% if item.0.type | default('ethernet') in ['ipoib', 'infiniband'] %}
 [infiniband]
 transport-mode=datagram
 {% if item.0.mtu is defined %}

--- a/templates/bridge_port_nmconnection.j2
+++ b/templates/bridge_port_nmconnection.j2
@@ -7,7 +7,7 @@ interface-name={{ item.1 }}
 controller={{ item.0.device }}
 port-type=bridge
 
-{% if item.0.type | default('ethernet')  == 'ipoib' %}
+{% if item.0.type | default('ethernet') in ['ipoib', 'infiniband'] %}
 [infiniband]
 transport-mode=datagram
 {% if item.mtu is defined %}

--- a/templates/ethernet_nmconnection.j2
+++ b/templates/ethernet_nmconnection.j2
@@ -20,7 +20,7 @@ port-type=bridge
 {%   endif %}
 {% endfor %}
 
-{% if item.type | default('ethernet')  == 'ipoib' %}
+{% if item.type | default('ethernet') in ['ipoib', 'infiniband'] %}
 [infiniband]
 transport-mode=datagram
 {% if item.mtu is defined %}


### PR DESCRIPTION
This matches the type used by NetworkManager. The other drivers do not appear to use the interface type in configuration, so no changes were needed there. I believe this follows the principle of least surprise.

Change-Id: I87d239536b9f5d1792bd100d8610b21010bf9476